### PR TITLE
Generate dynarec AND interpreter on iOS (with single invocation!)

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -56,7 +56,12 @@ else ifeq ($(platform), osx)
 # iOS
 else ifeq ($(platform), ios)
 	ARCH := arm
+	USE_DYNAREC ?= 1
 	TARGET := $(TARGET_NAME)_libretro_ios.dylib
+ifeq ($(USE_DYNAREC),0)
+	# Override
+	TARGET := $(TARGET_NAME)_interpreter_libretro_ios.dylib
+endif
 	fpic := -fPIC
 	SHARED := -dynamiclib
 
@@ -71,7 +76,6 @@ else ifeq ($(platform), ios)
 	ASFLAGS += -mcpu=cortex-a8 -mtune=cortex-a8 -mfpu=neon
 	HAVE_NEON = 1
 	BUILTIN_GPU = neon
-	USE_DYNAREC = 1
 	CFLAGS += -DIOS
 	OSXVER = `sw_vers -productVersion | cut -d. -f 2`
 	OSX_LT_MAVERICKS = `(( $(OSXVER) <= 9)) && echo "YES"`
@@ -200,6 +204,14 @@ BUILTIN_GPU ?= peops
 SOUND_DRIVERS = libretro
 PLUGINS =
 NO_CONFIG_MAK = yes
+
+libretro_all: all
+ifeq ($(platform),ios)
+ifeq ($(USE_DYNAREC),1)
+	make -f Makefile.libretro USE_DYNAREC=0 platform=$(platform) clean
+	make -f Makefile.libretro USE_DYNAREC=0 platform=$(platform)
+endif
+endif
 
 include Makefile
 


### PR DESCRIPTION
This is NOT the cleanest way to do this, and I intend to revisit it later to see if I can improve upon it.  (How easy that will be depends on upstream support questions.)

For now what I've done is:

1. Override the default rule to be one that depends on all
2. Rename the output target to pcsx_rearmed_interpreter_libretro_ios.dylib on iOS when USE_DYNAREC is 0.
3. Our overridden rule cleans the project and reruns make with USE_DYNAREC=0 on iOS only.

This is actually a step backward for libretro-super, but it'll allow me to take two steps forward.