### PR TITLE
Poll analog inputs of pad2 when it's an analog pad.

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -51,6 +51,7 @@ extern char McdDisable[2];
 /* PCSX ReARMed core calls and stuff */
 int in_type1, in_type2;
 int in_a1[2] = { 127, 127 }, in_a2[2] = { 127, 127 };
+int in_a3[2] = { 127, 127 }, in_a4[2] = { 127, 127 };
 int in_keystate;
 int in_enable_vibration = 1;
 
@@ -1123,6 +1124,14 @@ void retro_run(void)
 		in_a1[1] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y) / 256) + 128;
 		in_a2[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128;
 		in_a2[1] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 256) + 128;
+	}
+
+	if (in_type2 == PSE_PAD_TYPE_ANALOGPAD)
+	{
+		in_a3[0] = (input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128;
+		in_a3[1] = (input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_Y) / 256) + 128;
+		in_a4[0] = (input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128;
+		in_a4[1] = (input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 256) + 128;
 	}
 
 	stop = 0;

--- a/frontend/plugin.c
+++ b/frontend/plugin.c
@@ -66,6 +66,12 @@ static long PADreadPort2(PadDataS *pad)
 {
 	pad->controllerType = in_type2;
 	pad->buttonStatus = ~in_keystate >> 16;
+	if (in_type2 == PSE_PAD_TYPE_ANALOGPAD) {
+		pad->leftJoyX = in_a3[0];
+		pad->leftJoyY = in_a3[1];
+		pad->rightJoyX = in_a4[0];
+		pad->rightJoyY = in_a4[1];
+	}
 	return 0;
 }
 

--- a/frontend/plugin_lib.h
+++ b/frontend/plugin_lib.h
@@ -18,7 +18,7 @@ enum {
 	DKEY_SQUARE,
 };
 extern int in_type1, in_type2;
-extern int in_keystate, in_state_gun, in_a1[2], in_a2[2];
+extern int in_keystate, in_state_gun, in_a1[2], in_a2[2], in_a3[2], in_a4[2];
 extern int in_adev[2], in_adev_axis[2][2];
 extern int in_adev_is_nublike[2];
 extern int in_enable_vibration;


### PR DESCRIPTION
Using two pads (xbox360 wireless clone) in analog mode:
pcsx_rearmed_pad1type = "analog"
pcsx_rearmed_pad2type = "analog"
Second controller analog input do not work. In Gran Turismo 2  second player
cannot use left analog joystick for steering. Proposed patch will enable
polling of second controller analog input when using libretro.