### PR TITLE
patch to support the neGcon racing controller

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1220,7 +1220,7 @@ static void update_variables(bool in_flight)
 
 void retro_run(void) 
 {
-	int i;
+	int i, val;
 
 	input_poll_cb();
 
@@ -1284,16 +1284,16 @@ void retro_run(void)
         if (in_type2 == PSE_PAD_TYPE_NEGCON)
         {
 		/* left brake */
-		if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, 12))
+		if(input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, 12))
 			in_a3[1] = 255;
               	else
 			in_a3[1] =  0;
 
 		/* steer */
-                in_a4[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128;
+                in_a4[0] = (input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128;
 
 		/* thrust and fire */
-                val = ((input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 127));
+                val = ((input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 127));
                 if(val < -2) {
                         in_a3[0] = 256 - val;
                 } 

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1257,30 +1257,54 @@ void retro_run(void)
 
         if (in_type1 == PSE_PAD_TYPE_NEGCON)
         {
-                in_a1[0] = 0;
-
-		if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, 12)) // left brake
+		/* left brake */
+		if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, 12))
 			in_a1[1] = 255;
               	else
 			in_a1[1] =  0;
 
+		/* steer */
+                in_a2[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128;
 
-                in_a2[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128; //steer
-                in_a2[1] = 255 - ((input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 256) + 128); //thrust
+		/* thrust and fire */
+                val = ((input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 127));
+                if(val < -2) {
+                        in_a1[0] = 256 - val;
+                } 
+                 if (val > 2) {
+                        in_a2[1] = val;
+                } 
+                if(val >= -2 && val <= 2)
+                {
+                        in_a2[1] = 0;
+                        in_a1[0] = 0;
+                }
         }
 
         if (in_type2 == PSE_PAD_TYPE_NEGCON)
         {
-                in_a3[0] = 0;
-
-		if(input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, 12)) // left brake
+		/* left brake */
+		if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, 12))
 			in_a3[1] = 255;
               	else
 			in_a3[1] =  0;
 
+		/* steer */
+                in_a4[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128;
 
-                in_a4[0] = (input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128; //steer
-                in_a4[1] = 255 - ((input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 256) + 128); //thrust
+		/* thrust and fire */
+                val = ((input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 127));
+                if(val < -2) {
+                        in_a3[0] = 256 - val;
+                } 
+                 if (val > 2) {
+                        in_a4[1] = val;
+                } 
+                if(val >= -2 && val <= 2)
+                {
+                        in_a4[1] = 0;
+                        in_a3[0] = 0;
+                }
         }
 
 

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -329,8 +329,8 @@ void retro_set_environment(retro_environment_t cb)
    static const struct retro_variable vars[] = {
       { "pcsx_rearmed_frameskip", "Frameskip; 0|1|2|3" },
       { "pcsx_rearmed_region", "Region; Auto|NTSC|PAL" },
-      { "pcsx_rearmed_pad1type", "Pad 1 Type; standard|analog" },
-      { "pcsx_rearmed_pad2type", "Pad 2 Type; standard|analog" },
+      { "pcsx_rearmed_pad1type", "Pad 1 Type; standard|analog|negcon" },
+      { "pcsx_rearmed_pad2type", "Pad 2 Type; standard|analog|negcon" },
 #ifndef DRC_DISABLE
       { "pcsx_rearmed_drc", "Dynamic recompiler; enabled|disabled" },
 #endif
@@ -1067,6 +1067,8 @@ static void update_variables(bool in_flight)
       in_type1 = PSE_PAD_TYPE_STANDARD;
       if (strcmp(var.value, "analog") == 0)
          in_type1 = PSE_PAD_TYPE_ANALOGPAD;
+      if (strcmp(var.value, "negcon") == 0)
+         in_type1 = PSE_PAD_TYPE_NEGCON;
    }
 
    var.value = NULL;
@@ -1077,6 +1079,9 @@ static void update_variables(bool in_flight)
       in_type2 = PSE_PAD_TYPE_STANDARD;
       if (strcmp(var.value, "analog") == 0)
          in_type2 = PSE_PAD_TYPE_ANALOGPAD;
+      if (strcmp(var.value, "negcon") == 0)
+         in_type2 = PSE_PAD_TYPE_NEGCON;
+
    }
 
 #ifdef __ARM_NEON__
@@ -1232,6 +1237,7 @@ void retro_run(void)
 		if (input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, i))
 			in_keystate |= retro_psx_map[i];
 
+
 	if (in_type1 == PSE_PAD_TYPE_ANALOGPAD)
 	{
 		in_a1[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_LEFT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128;
@@ -1247,6 +1253,36 @@ void retro_run(void)
 		in_a4[0] = (input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128;
 		in_a4[1] = (input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 256) + 128;
 	}
+
+
+        if (in_type1 == PSE_PAD_TYPE_NEGCON)
+        {
+                in_a1[0] = 0;
+
+		if(input_state_cb(0, RETRO_DEVICE_JOYPAD, 0, 12)) // left brake
+			in_a1[1] = 255;
+              	else
+			in_a1[1] =  0;
+
+
+                in_a2[0] = (input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128; //steer
+                in_a2[1] = 255 - ((input_state_cb(0, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 256) + 128); //thrust
+        }
+
+        if (in_type2 == PSE_PAD_TYPE_NEGCON)
+        {
+                in_a3[0] = 0;
+
+		if(input_state_cb(1, RETRO_DEVICE_JOYPAD, 0, 12)) // left brake
+			in_a3[1] = 255;
+              	else
+			in_a3[1] =  0;
+
+
+                in_a4[0] = (input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_X) / 256) + 128; //steer
+                in_a4[1] = 255 - ((input_state_cb(1, RETRO_DEVICE_ANALOG, RETRO_DEVICE_INDEX_ANALOG_RIGHT, RETRO_DEVICE_ID_ANALOG_Y) / 256) + 128); //thrust
+        }
+
 
 	stop = 0;
 	psxCpu->Execute();

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -308,12 +308,12 @@ static void menu_sync_config(void)
 
 	switch (in_type_sel1) {
 	case 1:  in_type1 = PSE_PAD_TYPE_ANALOGPAD; break;
-	case 2:  in_type1 = PSE_PAD_TYPE_GUNCON;    break;
+	case 2:  in_type1 = PSE_PAD_TYPE_NEGCON;    break;
 	default: in_type1 = PSE_PAD_TYPE_STANDARD;
 	}
 	switch (in_type_sel2) {
 	case 1:  in_type2 = PSE_PAD_TYPE_ANALOGPAD; break;
-	case 2:  in_type2 = PSE_PAD_TYPE_GUNCON;    break;
+	case 2:  in_type2 = PSE_PAD_TYPE_NEGCON;    break;
 	default: in_type2 = PSE_PAD_TYPE_STANDARD;
 	}
 	if (in_evdev_allow_abs_only != allow_abs_only_old) {

--- a/frontend/plugin.c
+++ b/frontend/plugin.c
@@ -53,12 +53,12 @@ static long PADreadPort1(PadDataS *pad)
 {
 	pad->controllerType = in_type1;
 	pad->buttonStatus = ~in_keystate;
-	if (in_type1 == PSE_PAD_TYPE_ANALOGPAD) {
-		pad->leftJoyX = in_a1[0];
-		pad->leftJoyY = in_a1[1];
-		pad->rightJoyX = in_a2[0];
-		pad->rightJoyY = in_a2[1];
-	}
+	if (in_type1 == PSE_PAD_TYPE_ANALOGPAD || in_type1 == PSE_PAD_TYPE_NEGCON) {
+                pad->leftJoyX = in_a1[0];
+                pad->leftJoyY = in_a1[1];
+                pad->rightJoyX = in_a2[0];
+                pad->rightJoyY = in_a2[1];
+        }
 	return 0;
 }
 
@@ -66,7 +66,7 @@ static long PADreadPort2(PadDataS *pad)
 {
 	pad->controllerType = in_type2;
 	pad->buttonStatus = ~in_keystate >> 16;
-	if (in_type2 == PSE_PAD_TYPE_ANALOGPAD) {
+	if (in_type2 == PSE_PAD_TYPE_ANALOGPAD || in_type2 == PSE_PAD_TYPE_NEGCON) {
 		pad->leftJoyX = in_a3[0];
 		pad->leftJoyY = in_a3[1];
 		pad->rightJoyX = in_a4[0];

--- a/plugins/dfinput/main.c
+++ b/plugins/dfinput/main.c
@@ -15,9 +15,6 @@
 #include <windows.h>
 #endif
 
-#include <stdio.h>
-#include <string.h>
-
 #include "main.h"
 
 unsigned char CurPad, CurByte, CurCmd, CmdLen;
@@ -56,16 +53,10 @@ static int old_controller_type1 = -1, old_controller_type2 = -1;
 		} \
 	}
 
-//                case PSE_PAD_TYPE_NEGCON: \
-//                        PAD##n##_startPoll = PADstartPoll_negcon; \
-//                        PAD##n##_poll = PADpoll_negcon; \
-//                        negcon_init(); \
-//                        break; \
 
 void dfinput_activate(void)
 {
 	PadDataS pad;
-	int i;
 
 	PAD1_readPort1(&pad);
 	select_pad(1);

--- a/plugins/dfinput/main.c
+++ b/plugins/dfinput/main.c
@@ -15,6 +15,9 @@
 #include <windows.h>
 #endif
 
+#include <stdio.h>
+#include <string.h>
+
 #include "main.h"
 
 unsigned char CurPad, CurByte, CurCmd, CmdLen;
@@ -44,6 +47,7 @@ static int old_controller_type1 = -1, old_controller_type2 = -1;
 			PAD##n##_poll = PADpoll_guncon; \
 			guncon_init(); \
 			break; \
+                case PSE_PAD_TYPE_NEGCON: \
 		case PSE_PAD_TYPE_GUN: \
 		default: \
 			PAD##n##_startPoll = PAD##n##__startPoll; \
@@ -52,9 +56,16 @@ static int old_controller_type1 = -1, old_controller_type2 = -1;
 		} \
 	}
 
+//                case PSE_PAD_TYPE_NEGCON: \
+//                        PAD##n##_startPoll = PADstartPoll_negcon; \
+//                        PAD##n##_poll = PADpoll_negcon; \
+//                        negcon_init(); \
+//                        break; \
+
 void dfinput_activate(void)
 {
 	PadDataS pad;
+	int i;
 
 	PAD1_readPort1(&pad);
 	select_pad(1);


### PR DESCRIPTION
Thanks for Retropie and all people involved. It is absolutely great to play Wipeout 2097 again after all these years. There is however one thing missing for the full experience, and that is playing with the neGcon steering wheel. For that I wrote (small) patch that enables neGcon controller functionality within Pcsx-Rearmed/Retropie. 

To get up-and-running is quite an adventure. The neGcon needs a USB Controller Adapter to connect with the Raspberry Pi. This adapter requires a special controller configuration file that translates the buttons and twist to the emulator. Finally, the correct Pad Type needs to be set in RGui so games are aware that a neGcon device is connected. (Rgui -> Quick Menu -> Core Options -> Pad 1 Type -> negcon)

The patch is working great. Games tested OK are Gran Turismo, NFS3 Hot Pursuit, Ridge Racer, Ridge Racer Type 4, Ray Tracers, Rally Cross 2, Rollcage I & II and of course Wipeout and Wipeout 2097/XL. For some reason V-Rally 2, Rage Racer and Wipeout 3/SE don’t accept any controller input after the game is started, so unfortunately these don’t work.

The neGcon button configuration file for the USB adapter, in my case the blue Twin USB converter, is an essential part of this patch. I have included it here so you can modify it for your own adapter.
Test, enjoy and merge this pull if you like it.

input_device = "Twin USB Joystick"
input_driver = "udev"
input_r_y_plus_axis = "-1"
input_r_x_minus_axis = "-0"
input_l1_axis = "-2"
input_l2_axis = "-2"
input_start_btn = "9"
input_exit_emulator_btn = "9"
input_up_btn = "h0up"
input_r_y_minus_axis = "+1"
input_a_btn = "1"
input_b_btn = "0"
input_x_btn = "0"
input_y_btn = "1"
input_reset_btn = "0"
input_down_btn = "h0down"
input_r1_btn = "7"
input_r2_btn = "7"
input_r_btn = "7"
input_right_btn = "h0right"
input_state_slot_increase_btn = "h0right"
input_left_btn = "h0left"
input_state_slot_decrease_btn = "h0left"
input_r_x_plus_axis = "+0"
