### PR TITLE
enhance neGcon compatibility

### DIFF
--- a/libpcsxcore/sio.c
+++ b/libpcsxcore/sio.c
@@ -117,6 +117,20 @@ void sioWrite8(unsigned char value) {
 							break;
 					}
 				}
+				// NegCon - Wipeout 3
+				if( buf[parp] == 0x23 ) {
+					switch (value) {
+						// enter config mode
+						case 0x43:
+							buf[1] = 0x79;
+							break;
+
+						// get status
+						case 0x45:
+							buf[1] = 0xf3;
+							break;
+					}
+				}
 			}
 			else padst = 0;
 			return;


### PR DESCRIPTION
This fix is borrowed from pcsxr. It adds neGcon compatibility for Wipeout3/SE and other games.
