### PR TITLE
Use DEBUG=1 properly for debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,10 @@
 
 # default stuff goes here, so that config can override
 TARGET ?= pcsx
-CFLAGS += -Wall -ggdb -Iinclude -ffast-math
-ifndef DEBUG
+CFLAGS += -Wall -Iinclude -ffast-math
+ifeq ($(DEBUG), 1)
+CFLAGS += -O0 -ggdb -DOPENGL_DEBUG
+else
 CFLAGS += -O2 -DNDEBUG
 endif
 CXXFLAGS += $(CFLAGS)

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -1,5 +1,7 @@
 # Makefile for PCSX ReARMed (libretro)
 
+DEBUG=0
+
 ifeq ($(platform),)
 	platform = unix
 	ifeq ($(shell uname -a),)


### PR DESCRIPTION
When compiling pcsx_rearmed with `make -f Makefile.libretro` both `DEBUG=1` and `DEBUG=0` will result in a debug build. This commit will make it so that `DEBUG=1` will result in `-O0 -ggdb -DOPENGL_DEBUG` while `DEBUG=0` and the default will be `-O2 -DNDEBUG` as it was before. Another change is that `-ggdb` will now only be used for debug builds where before it was used regardless.