### PR TITLE
OPENGL_DEBUG is not needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 TARGET ?= pcsx
 CFLAGS += -Wall -Iinclude -ffast-math
 ifeq ($(DEBUG), 1)
-CFLAGS += -O0 -ggdb -DOPENGL_DEBUG
+CFLAGS += -O0 -ggdb
 else
 CFLAGS += -O2 -DNDEBUG
 endif


### PR DESCRIPTION
pcsx_rearmed is software only so `-DOPENGL_DEBUG` is not really needed...I'm not sure what I was thinking when I added it.