### PR TITLE
Fix build error about undefined reference to `deinit_vita_mmap'

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1658,8 +1658,10 @@ void retro_deinit(void)
 	free(vout_buf);
 #endif
 	vout_buf = NULL;
-  
+
+#ifdef VITA
   deinit_vita_mmap();
+#endif
 }
 
 #ifdef VITA


### PR DESCRIPTION
```
frontend/libretro.o: In function `retro_deinit':
libretro.c:(.text+0x3769): undefined reference to `deinit_vita_mmap'
collect2: error: ld returned 1 exit status
make: *** [pcsx_rearmed_libretro.so] Error 1
```
Introduced #68