### PR TITLE
Report git version with library_version

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -22,6 +22,10 @@ CC_AS ?= $(CC)
 CFLAGS ?=
 
 TARGET_NAME := pcsx_rearmed
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 LIBZ := -lz
 LIBPTHREAD := -lpthread
 LIBDL := -ldl

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -638,7 +638,10 @@ void retro_get_system_info(struct retro_system_info *info)
 {
 	memset(info, 0, sizeof(*info));
 	info->library_name = "PCSX-ReARMed";
-	info->library_version = "r22";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
+	info->library_version = "r22" GIT_VERSION;
 	info->valid_extensions = "bin|cue|img|mdf|pbp|toc|cbn|m3u";
 	info->need_fullpath = true;
 }

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -2,6 +2,11 @@ LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+	LOCAL_CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 APP_DIR := ../../src
 
 #fix stupid change in ndk r11 that breaks compiling even when the exe would run fine


### PR DESCRIPTION
This patch makes this core report the git version along with its library_version. This is important because otherwise it is impossible to replicate a build without extra knowledge, and things like Netplay that demand versions be the same can't be reliably known to work.