### PR TITLE
Rename uncompress2 to avoid conflicts with zlib.h on some systems

### DIFF
--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -1093,7 +1093,7 @@ static int cdread_sub_mixed(FILE *f, unsigned int base, void *dest, int sector)
 	return ret;
 }
 
-static int uncompress2(void *out, unsigned long *out_size, void *in, unsigned long in_size)
+static int uncomp2(void *out, unsigned long *out_size, void *in, unsigned long in_size)
 {
 	static z_stream z;
 	int ret = 0;
@@ -1173,7 +1173,7 @@ static int cdread_compressed(FILE *f, unsigned int base, void *dest, int sector)
 	if (is_compressed) {
 		cdbuffer_size_expect = sizeof(compr_img->buff_raw[0]) << compr_img->block_shift;
 		cdbuffer_size = cdbuffer_size_expect;
-		ret = uncompress2(compr_img->buff_raw[0], &cdbuffer_size, compr_img->buff_compressed, size);
+		ret = uncomp2(compr_img->buff_raw[0], &cdbuffer_size, compr_img->buff_compressed, size);
 		if (ret != 0) {
 			SysPrintf("uncompress failed with %d for block %d, sector %d\n",
 					ret, block, sector);

--- a/plugins/cdrcimg/cdrcimg.c
+++ b/plugins/cdrcimg/cdrcimg.c
@@ -100,7 +100,7 @@ static long CDRgetTD(unsigned char track, unsigned char *buffer)
 	return 0;
 }
 
-int uncompress2(void *out, unsigned long *out_size, void *in, unsigned long in_size)
+int uncomp2(void *out, unsigned long *out_size, void *in, unsigned long in_size)
 {
 	static z_stream z;
 	int ret = 0;
@@ -201,7 +201,7 @@ static long CDRreadTrack(unsigned char *time)
 		ret = uncompress(cdbuffer->raw[0], &cdbuffer_size, cdbuffer->compressed, size);
 		break;
 	case CDRC_ZLIB2:
-		ret = uncompress2(cdbuffer->raw[0], &cdbuffer_size, cdbuffer->compressed, size);
+		ret = uncomp2(cdbuffer->raw[0], &cdbuffer_size, cdbuffer->compressed, size);
 		break;
 	case CDRC_BZ:
 		ret = pBZ2_bzBuffToBuffDecompress((char *)cdbuffer->raw, (unsigned int *)&cdbuffer_size,


### PR DESCRIPTION
I am not sure if this is the best solution, but it works for me and probably at least could give an idea to a better solution.

This fixes https://github.com/libretro/pcsx_rearmed/issues/87.