### PR TITLE
Enable support for multiline cheats.

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -39,6 +39,9 @@
 
 #define PORTS_NUMBER 8
 
+#define ISHEXDEC ((buf[cursor]>='0') && (buf[cursor]<='9')) || ((buf[cursor]>='a') && (buf[cursor]<='f')) || ((buf[cursor]>='A') && (buf[cursor]<='F'))
+
+
 //hack to prevent retroarch freezing when reseting in the menu but not while running with the hot key
 int rebootemu = 0;
 
@@ -776,6 +779,21 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 	// cheat funcs are destructive, need a copy..
 	strncpy(buf, code, sizeof(buf));
 	buf[sizeof(buf) - 1] = 0;
+	
+	//Prepare buffered cheat for PCSX's AddCheat fucntion.
+	int cursor=0;
+	int nonhexdec=0;
+	while (buf[cursor]){
+		if (!(ISHEXDEC)){
+			if (++nonhexdec%2){
+				buf[cursor]=' ';
+			} else {
+				buf[cursor]='\n';
+			}
+		}
+		cursor++;
+	}
+	
 
 	if (index < NumCheats)
 		ret = EditCheat(index, "", buf);
@@ -783,7 +801,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 		ret = AddCheat("", buf);
 
 	if (ret != 0)
-		SysPrintf("Failed to set cheat %#u\n", index);
+		SysPrintf("Failed to set cheat %#u: %s\n", index, code);
 	else if (index < NumCheats)
 		Cheats[index].Enabled = enabled;
 }

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -41,7 +41,6 @@
 
 #define ISHEXDEC ((buf[cursor]>='0') && (buf[cursor]<='9')) || ((buf[cursor]>='a') && (buf[cursor]<='f')) || ((buf[cursor]>='A') && (buf[cursor]<='F'))
 
-
 //hack to prevent retroarch freezing when reseting in the menu but not while running with the hot key
 int rebootemu = 0;
 
@@ -801,7 +800,7 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
 		ret = AddCheat("", buf);
 
 	if (ret != 0)
-		SysPrintf("Failed to set cheat %#u: %s\n", index, code);
+		SysPrintf("Failed to set cheat %#u\n", index);
 	else if (index < NumCheats)
 		Cheats[index].Enabled = enabled;
 }


### PR DESCRIPTION
All non hexdec characters will be read as delimiters and reformatted for PCSX's preferred format, which means a space between code parts and newline between code lines.

Fixes #90 