### PR TITLE
libretro: Remove reset in retro_run() hack

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1308,9 +1308,7 @@ size_t retro_get_memory_size(unsigned id)
 
 void retro_reset(void)
 {
-   //hack to prevent retroarch freezing when reseting in the menu but not while running with the hot key
-   rebootemu = 1;
-	//SysReset();
+	SysReset();
 }
 
 static const unsigned short retro_psx_map[] = {
@@ -1517,11 +1515,6 @@ static int min(int a, int b)
 void retro_run(void)
 {
     int i;
-    //SysReset must be run while core is running,Not in menu (Locks up Retroarch)
-    if(rebootemu != 0){
-      rebootemu = 0;
-      SysReset();
-    }
 
 	input_poll_cb();
 


### PR DESCRIPTION
Removes a hack breaking deserialization when running retro_reset(), retro_unserialize() and retro_run() in this order, as it silently resets the core just after setting its state.

I don't know how to properly fix the problem encountered in RA but silently reseting the core in retro_run() isn't the right solution as the core isn't reset after running retro_reset() and as it introduces other bugs.