### PR TITLE
More clear HLE BIOS error message

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1680,7 +1680,7 @@ void retro_init(void)
 		SysPrintf("no BIOS files found.\n");
 		struct retro_message msg =
 		{
-			"no BIOS found, expect bugs!",
+			"No BIOS file found - add for better compatibility",
 			180
 		};
 		environ_cb(RETRO_ENVIRONMENT_SET_MESSAGE, (void*)&msg);


### PR DESCRIPTION
The current message shown when there is no BIOS file doesn't make it clear that one can be added