### PR TITLE
Use dynamic base address for 3ds

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -155,7 +155,7 @@ else ifeq ($(platform), ctr)
 #	CFLAGS += -DPCSX
 #	BUILTIN_GPU = unai
 	USE_DYNAREC = 1
-	DRC_CACHE_BASE = 1
+	DRC_CACHE_BASE = 0
 	ARCH = arm
 	HAVE_NEON = 0
 


### PR DESCRIPTION
To be honest, I have no idea of what I'm doing here.

This is a fix for #125. The increasing size of global variables in RetroArch codebase causes the BASE_ADDR to overlap with some of the variables, resulting in a crash.

I don't know if there's a reason why dynamic base is not used for 3ds. According to my tests everything seem to be working fine.