### PR TITLE
Support memcard2

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1727,7 +1727,7 @@ void retro_init(void)
 	spu_config.iUseFixedUpdates = 1;
 
 	McdDisable[0] = 0;
-	McdDisable[1] = 1;
+	McdDisable[1] = 0;
 	init_memcard(Mcd1Data);
    init_memcard(Mcd2Data);
 

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1667,7 +1667,15 @@ void retro_init(void)
    if(!__ctr_svchax)
       Config.Cpu = CPU_INTERPRETER;
 #endif
-	strcpy(Config.Mcd2, "memcard2.mcd");
+	if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir) && dir) {
+		const char CARD_FILE[] = "pcsx-card2.mcd";
+		if (strlen(dir) + strlen(CARD_FILE) + 2 > sizeof(Config.Mcd2)) {
+			SysPrintf("Path '%s' is too long. Cannot use memcard 2. Use a shorter path.\n", dir);
+		} else {
+			snprintf(Config.Mcd2, sizeof(Config.Mcd2), "%s/%s", dir, CARD_FILE);
+			SysPrintf("Use memory card2: %s\n", Config.Mcd2);
+		}
+	}
 
 	ret |= emu_core_init();
 	if (ret != 0) {

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1667,6 +1667,7 @@ void retro_init(void)
    if(!__ctr_svchax)
       Config.Cpu = CPU_INTERPRETER;
 #endif
+	strcpy(Config.Mcd2, "memcard2.mcd");
 
 	ret |= emu_core_init();
 	if (ret != 0) {
@@ -1729,7 +1730,6 @@ void retro_init(void)
 	McdDisable[0] = 0;
 	McdDisable[1] = 0;
 	init_memcard(Mcd1Data);
-   init_memcard(Mcd2Data);
 
 	SaveFuncs.open = save_open;
 	SaveFuncs.read = save_read;

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -438,6 +438,7 @@ void retro_set_environment(retro_environment_t cb)
    static const struct retro_variable vars[] = {
       { "pcsx_rearmed_frameskip", "Frameskip; 0|1|2|3" },
       { "pcsx_rearmed_region", "Region; auto|NTSC|PAL" },
+      { "pcsx_rearmed_memcard2", "Enable second memory card; disabled|enabled" },
       { "pcsx_rearmed_pad1type", "Pad 1 Type; default|none|standard|analog|negcon" },
       { "pcsx_rearmed_pad2type", "Pad 2 Type; default|none|standard|analog|negcon" },
       { "pcsx_rearmed_pad3type", "Pad 3 Type; default|none|standard|analog|negcon" },
@@ -1637,6 +1638,41 @@ static void check_system_specs(void)
    environ_cb(RETRO_ENVIRONMENT_SET_PERFORMANCE_LEVEL, &level);
 }
 
+static int init_memcards(void)
+{
+	int ret = 0;
+	const char *dir;
+	struct retro_variable var = { .key="pcsx_rearmed_memcard2", .value=NULL };
+	static const char CARD2_FILE[] = "pcsx-card2.mcd";
+
+	McdDisable[0] = 0;
+	// Disable memcard 2 by default
+	McdDisable[1] = 1;
+	init_memcard(Mcd1Data);
+	// Memcard 2 is managed by the emulator on the filesystem,
+	// There is no need to initialize Mcd2Data like Mcd1Data.
+
+	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
+		SysPrintf("Memcard 2: %s\n", var.value);
+		if (memcmp(var.value, "enabled", 7) == 0) {
+			if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir) && dir) {
+				if (strlen(dir) + strlen(CARD2_FILE) + 2 > sizeof(Config.Mcd2)) {
+					SysPrintf("Path '%s' is too long. Cannot use memcard 2. Use a shorter path.\n", dir);
+					ret = -1;
+				} else {
+					McdDisable[1] = 0;
+					snprintf(Config.Mcd2, sizeof(Config.Mcd2), "%s/%s", dir, CARD2_FILE);
+					SysPrintf("Use memcard 2: %s\n", Config.Mcd2);
+				}
+			} else {
+				SysPrintf("Could not get save directory! Could not create memcard 2.");
+				ret = -1;
+			}
+		}
+	}
+	return ret;
+}
+
 void retro_init(void)
 {
 	const char *bios[] = { "SCPH101", "SCPH7001", "SCPH5501", "SCPH1001" };
@@ -1667,15 +1703,7 @@ void retro_init(void)
    if(!__ctr_svchax)
       Config.Cpu = CPU_INTERPRETER;
 #endif
-	if (environ_cb(RETRO_ENVIRONMENT_GET_SAVE_DIRECTORY, &dir) && dir) {
-		const char CARD_FILE[] = "pcsx-card2.mcd";
-		if (strlen(dir) + strlen(CARD_FILE) + 2 > sizeof(Config.Mcd2)) {
-			SysPrintf("Path '%s' is too long. Cannot use memcard 2. Use a shorter path.\n", dir);
-		} else {
-			snprintf(Config.Mcd2, sizeof(Config.Mcd2), "%s/%s", dir, CARD_FILE);
-			SysPrintf("Use memory card2: %s\n", Config.Mcd2);
-		}
-	}
+	ret |= init_memcards();
 
 	ret |= emu_core_init();
 	if (ret != 0) {
@@ -1734,10 +1762,6 @@ void retro_init(void)
 #endif
 	pl_rearmed_cbs.gpu_peops.iUseDither = 1;
 	spu_config.iUseFixedUpdates = 1;
-
-	McdDisable[0] = 0;
-	McdDisable[1] = 0;
-	init_memcard(Mcd1Data);
 
 	SaveFuncs.open = save_open;
 	SaveFuncs.read = save_read;


### PR DESCRIPTION
Hi. I was frustrated that memcard2 was not supported, so I decided to hack into the code.
I've been playing for a day and cleared a game where I needed two memory cards without issue.

Are you for/against this change?

- The memcard2 is automatically set to a file named `pcsx-card2.mcd` in the folder of the loaded game. Maybe we should make that configurable? If so, how?

