### PR TITLE
Fix negCon input mapping

### DIFF
--- a/frontend/libretro.h
+++ b/frontend/libretro.h
@@ -195,6 +195,7 @@ extern "C" {
 /* Index / Id values for ANALOG device. */
 #define RETRO_DEVICE_INDEX_ANALOG_LEFT   0
 #define RETRO_DEVICE_INDEX_ANALOG_RIGHT  1
+#define RETRO_DEVICE_INDEX_ANALOG_BUTTON 2
 #define RETRO_DEVICE_ID_ANALOG_X         0
 #define RETRO_DEVICE_ID_ANALOG_Y         1
 


### PR DESCRIPTION
While the core nominally supports virtual negCon devices, the current implementation is broken and unusable. This pull request just remaps negCon input to match the setup in the beetle-psx core, as follows:

Digital input:

- negCon d-pad: RetroPad d-pad
- negCon Start: RetroPad Start
- neGcon A: RetroPad A
- neGcon B: RetroPad X
- neGcon R shoulder: RetroPad R

Analog input:

- neGcon twist: RetroPad left analog (x-axis)
- neGcon I: RetroPad R2 or B
- neGcon II: RetroPad L2 or Y
- neGcon L shoulder: RetroPad L

As with the beetle-psx core, the analog inputs make use of the RetroArch 'analog button' feature - so most modern gamepads should allow for 'proper' analog acceleration/breaking (in racing games) via the right/left triggers.