### PR TITLE
Fix segfault when loading cue files from relative paths.

### DIFF
--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -565,20 +565,15 @@ static int parsecue(const char *isofile) {
 			if (t != 1)
 				sscanf(linebuf, " FILE %255s", tmpb);
 
-			// absolute path?
-			ti[numtracks + 1].handle = fopen(tmpb, "rb");
-			if (ti[numtracks + 1].handle == NULL) {
-				// relative to .cue?
-				tmp = strrchr(tmpb, '\\');
-				if (tmp == NULL)
-					tmp = strrchr(tmpb, '/');
-				if (tmp != NULL)
-					tmp++;
-				else
-					tmp = tmpb;
-				strncpy(incue_fname, tmp, incue_max_len);
-				ti[numtracks + 1].handle = fopen(filepath, "rb");
-			}
+			tmp = strrchr(tmpb, '\\');
+			if (tmp == NULL)
+				tmp = strrchr(tmpb, '/');
+			if (tmp != NULL)
+				tmp++;
+			else
+				tmp = tmpb;
+			strncpy(incue_fname, tmp, incue_max_len);
+			ti[numtracks + 1].handle = fopen(filepath, "rb");
 
 			// update global offset if this is not first file in this .cue
 			if (numtracks + 1 > 1) {


### PR DESCRIPTION
Fixes https://github.com/libretro/pcsx_rearmed/issues/63

I tested without issues:
* Loading content with relative paths (`foo/bar.cue`, `./bar.cue` and `bar.cue`)
* Loading content with absolute paths.
* Loading content from the menu with `Load Content`.
* Loading content from the menu with a playlist.

Before this it would fail with relative paths like `./bar.cue` or segfault with `bar.cue`.