### PR TITLE
Hide nonfunctional NEON options in aarch64

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -481,7 +481,7 @@ void retro_set_environment(retro_environment_t cb)
 #ifndef DRC_DISABLE
       { "pcsx_rearmed_drc", "Dynamic recompiler; enabled|disabled" },
 #endif
-#ifdef __ARM_NEON__
+#if defined(__ARM_NEON__) && !defined(__aarch64__)
       { "pcsx_rearmed_neon_interlace_enable", "Enable interlacing mode(s); disabled|enabled" },
       { "pcsx_rearmed_neon_enhancement_enable", "Enhanced resolution (slow); disabled|enabled" },
       { "pcsx_rearmed_neon_enhancement_no_main", "Enhanced resolution speed hack; disabled|enabled" },


### PR DESCRIPTION
closes https://github.com/libretro/pcsx_rearmed/issues/219#issuecomment-458348900