### PR TITLE
Core fixes

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -36,6 +36,7 @@ LIBDL := -lroot -lnetwork
 else
 LIBDL := -ldl
 endif
+LIBM := -lm
 MMAP_WIN32=0
 EXTRA_LDFLAGS =
 
@@ -54,6 +55,7 @@ else ifeq ($(platform), linux-portable)
 	LIBZ :=
 	LIBPTHREAD :=
 	LIBDL :=
+	LIBM :=
 	NO_UNDEF_CHECK = 1
 
 # OS X
@@ -215,6 +217,7 @@ else ifeq ($(platform), qnx)
 	MAIN_LDLIBS += -lsocket
 	LIBPTHREAD :=
 	LIBDL :=
+	LIBM :=
 
 #Raspberry Pi 2
 else ifeq ($(platform), rpi2)
@@ -317,11 +320,12 @@ else
 	MAIN_LDLIBS += -lws2_32
 	LIBPTHREAD :=
 	LIBDL :=
+	LIBM :=
 endif
 
 CFLAGS += $(fpic)
 MAIN_LDFLAGS += -shared
-MAIN_LDLIBS += $(LIBPTHREAD) $(LIBDL) $(LIBZ)
+MAIN_LDLIBS += $(LIBPTHREAD) $(LIBM) $(LIBDL) $(LIBZ)
 
 # try to autodetect stuff for the lazy
 ifndef ARCH

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1289,7 +1289,10 @@ bool retro_load_game(const struct retro_game_info *info)
 		return false;
 	}
 
-	SysReset();
+	/* TODO: Calling SysReset() outside retro_run for some system
+	 * causes RetroArch to freeze, e.g Ludo */
+	//SysReset();
+	rebootemu = 1;
 
 	if (LoadCdrom() == -1) {
 		log_cb(RETRO_LOG_INFO, "could not load CD\n");

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1633,7 +1633,6 @@ void retro_run(void)
 		if (!Config.HLE && !Config.SlowBoot) {
 			// skip BIOS logos
 			psxRegs.pc = psxRegs.GPR.n.ra;
-			return 0;
 		}
     }
 

--- a/libpcsxcore/misc.c
+++ b/libpcsxcore/misc.c
@@ -180,7 +180,7 @@ int LoadCdrom() {
 	// is just below, do it here
 	fake_bios_gpu_setup();
 
-	if (!Config.HLE) {
+	if (!Config.HLE && !Config.SlowBoot) {
 		// skip BIOS logos
 		psxRegs.pc = psxRegs.GPR.n.ra;
 		return 0;

--- a/libpcsxcore/psxcommon.h
+++ b/libpcsxcore/psxcommon.h
@@ -119,6 +119,7 @@ typedef struct {
 	boolean PsxAuto;
 	boolean Cdda;
 	boolean HLE;
+	boolean SlowBoot;
 	boolean Debug;
 	boolean PsxOut;
 	boolean SpuIrq;


### PR DESCRIPTION
958c981 Fix CD audio not playing on some platforms 
- related post https://github.com/libretro/pcsx_rearmed/issues/224
- this needs verification as to which platforms supports -lm for linking

79f29e0 Fix detection for rumble interface
- rumble interface is always assumed is available, causing it to crash when rumble core option is left to enabled (default). This detects if rumble interface is available before sending rumble states.

0963774  Run SysReset() only from retro_run, causes retroarch to freeze...
- SysReset() crashes when loading with a real bios file if it is not called from retro_run(). This is already known based on an already added workaround from previous commit. This moves SysReset() from retro_load_game() to retro_run(). Can't figure out the "why" this happens though and why it gets fixed this way.
related post: https://github.com/libretro/pcsx_rearmed/issues/227

f422f44  Fix show bios bootlogo core option
- proper function of this core option based on available implementation. See LoadCdrom()
- related https://github.com/libretro/pcsx_rearmed/issues/105



