### PR TITLE
gpu_unai buildfix and re-enable on 3ds

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -177,7 +177,7 @@ else ifeq ($(platform), ctr)
 	CFLAGS += -Werror=implicit-function-declaration
 
 #	CFLAGS += -DPCSX
-#	BUILTIN_GPU = unai
+	BUILTIN_GPU = unai
 	USE_DYNAREC = 1
 	DRC_CACHE_BASE = 0
 	ARCH = arm

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -91,7 +91,7 @@ ifeq ($(TARGET_ARCH_ABI),armeabi-v7a)
                  $(FRONTEND_DIR)/cspace_neon.S
   SOURCES_C   += $(NEON_DIR)/psx_gpu_if.c
 else ifeq ($(TARGET_ARCH_ABI),armeabi)
-  SOURCES_ASM += $(UNAI_DIR)/gpu_arm.s \
+  SOURCES_ASM += $(UNAI_DIR)/gpu_arm.S \
                  $(FRONTEND_DIR)/cspace_arm.S
   SOURCES_C += $(UNAI_DIR)/gpulib_if.cpp
 else

--- a/plugins/gpu_unai/gpu_arm.S
+++ b/plugins/gpu_unai/gpu_arm.S
@@ -5,6 +5,7 @@
  * See the COPYING file in the top-level directory.
  */
 
+#include "arm_features.h"
 
 .text
 .align 2

--- a/plugins/gpu_unai/gpulib_if.cpp
+++ b/plugins/gpu_unai/gpulib_if.cpp
@@ -297,7 +297,7 @@ int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
       case 0x48 ... 0x4F:
       {
         u32 num_vertexes = 1;
-        u32 *list_position = &(list[2]);
+        u32 *list_position = (u32*)&(list[2]);
 
         gpuDrawLF(gpuPixelDrivers [ (Blending_Mode | Masking | Blending | (PixelMSB>>3)) >> 1]);
 
@@ -308,7 +308,7 @@ int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
           gpuDrawLF(gpuPixelDrivers [ (Blending_Mode | Masking | Blending | (PixelMSB>>3)) >> 1]);
 
           num_vertexes++;
-          if(list_position >= list_end) {
+          if(list_position >= (u32*)list_end) {
             cmd = -1;
             goto breakloop;
           }
@@ -330,7 +330,7 @@ int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
       case 0x58 ... 0x5F:
       {
         u32 num_vertexes = 1;
-        u32 *list_position = &(list[2]);
+        u32 *list_position = (u32*)&(list[2]);
 
         gpuDrawLG(gpuPixelDrivers [ (Blending_Mode | Masking | Blending | (PixelMSB>>3)) >> 1]);
 
@@ -343,7 +343,7 @@ int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
           gpuDrawLG(gpuPixelDrivers [ (Blending_Mode | Masking | Blending | (PixelMSB>>3)) >> 1]);
 
           num_vertexes++;
-          if(list_position >= list_end) {
+          if(list_position >= (u32*)list_end) {
             cmd = -1;
             goto breakloop;
           }


### PR DESCRIPTION
- gpulib_if.cpp: fix some -fpermissive issues during build
- renamed gpu_unai/gpu_arm.s to gpu_arm.S and added necessary header
- update Android.mk for unai (used in armeabi)
- re-enabled unai or 3DS

reference post : https://github.com/libretro/pcsx_rearmed/issues/188