### PR TITLE
Reverts 0963774 (Run SysRese) only from...)

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1297,10 +1297,7 @@ bool retro_load_game(const struct retro_game_info *info)
 		return false;
 	}
 
-	/* TODO: Calling SysReset() outside retro_run for some system
-	 * causes RetroArch to freeze, e.g Ludo */
-	//SysReset();
-	rebootemu = 1;
+	SysReset();
 
 	if (LoadCdrom() == -1) {
 		log_cb(RETRO_LOG_INFO, "could not load CD\n");


### PR DESCRIPTION
This reverts commit https://github.com/libretro/pcsx_rearmed/commit/0963774720493115d123104f9ddc506d49a886bc, which was added to remedy issue on ludo when using official bios. turns out if has affected HLE on arm. Other arm users so far don't have issue with this PR nor they gained any advantage over it so issue probably is just ludo exclusive. 

Reverting this.