### PR TITLE
GPU unai update

### DIFF
--- a/plugins/gpu_unai/gpulib_if.cpp
+++ b/plugins/gpu_unai/gpulib_if.cpp
@@ -165,11 +165,11 @@ void renderer_notify_res_change(void)
 
 extern const unsigned char cmd_lengths[256];
 
-int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
+int do_cmd_list(u32 *list, int list_len, int *last_cmd)
 {
-  unsigned int cmd = 0, len, i;
-  unsigned int *list_start = list;
-  unsigned int *list_end = list + list_len;
+  u32 cmd = 0, len, i;
+  u32 *list_start = list;
+  u32 *list_end = list + list_len;
 
   linesInterlace = force_interlace;
 #ifdef HAVE_PRE_ARMV7 /* XXX */
@@ -297,7 +297,7 @@ int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
       case 0x48 ... 0x4F:
       {
         u32 num_vertexes = 1;
-        u32 *list_position = (u32*)&(list[2]);
+        u32 *list_position = &(list[2]);
 
         gpuDrawLF(gpuPixelDrivers [ (Blending_Mode | Masking | Blending | (PixelMSB>>3)) >> 1]);
 
@@ -308,7 +308,7 @@ int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
           gpuDrawLF(gpuPixelDrivers [ (Blending_Mode | Masking | Blending | (PixelMSB>>3)) >> 1]);
 
           num_vertexes++;
-          if(list_position >= (u32*)list_end) {
+          if(list_position >= list_end) {
             cmd = -1;
             goto breakloop;
           }
@@ -330,7 +330,7 @@ int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
       case 0x58 ... 0x5F:
       {
         u32 num_vertexes = 1;
-        u32 *list_position = (u32*)&(list[2]);
+        u32 *list_position = &(list[2]);
 
         gpuDrawLG(gpuPixelDrivers [ (Blending_Mode | Masking | Blending | (PixelMSB>>3)) >> 1]);
 
@@ -343,7 +343,7 @@ int do_cmd_list(unsigned int *list, int list_len, int *last_cmd)
           gpuDrawLG(gpuPixelDrivers [ (Blending_Mode | Masking | Blending | (PixelMSB>>3)) >> 1]);
 
           num_vertexes++;
-          if(list_position >= (u32*)list_end) {
+          if(list_position >= list_end) {
             cmd = -1;
             goto breakloop;
           }


### PR DESCRIPTION
on CTR(3DS) compiling the core using **make platform=ctr** or **libretro-build-ctr.sh pcsx_rearmed** successfully creates pcsx_rearmed_libretro_ctr.a file.
When creating core with retroarch using **<retroarch-repo>/dists-scripts/dist-cores.sh ctr**, it fails to create a .3dsx or .cia files for both retroarch and pcsx_rearmed core showing this error:

```
/opt/devkitpro/devkitARM/bin/arm-none-eabi-g++ -specs=ctr/3dsx_custom.specs -g -march=armv6k -mtune=mpcore -mfloat-abi=hard -marm -mfpu=vfp -mtp=soft -Wl,-Map,.map  gfx/drivers/ctr_shaders/ctr_sprite.o ctr/ctr_system.o ctr/ctr_memory.o ctr/ctr_linear.o ctr/gpu_old.o ctr/exec-3dsx/exec_cia.o ctr/exec-3dsx/exec_3dsx.o ctr/exec-3dsx/mini-hb-menu/launch.o ctr/exec-3dsx/mini-hb-menu/loaders/rosalina.o ctr/exec-3dsx/mini-hb-menu/loaders/hax2.o ctr/exec-3dsx/mini-hb-menu/loaders/ninjhax1.o ctr/ctr_svchax.o griffin/griffin.o -L. -L/opt/devkitpro/libctru/lib  -lretro_ctr  -lm -lctru -o retroarch_3ds.elf
./libretro_ctr.a(gpu.o): In function `decide_frameskip':
gpu.c:(.text+0x258): undefined reference to `do_cmd_list'
./libretro_ctr.a(gpu.o): In function `do_cmd_list_skip':
gpu.c:(.text+0x514): undefined reference to `do_cmd_list'
./libretro_ctr.a(gpu.o): In function `do_cmd_buffer':
gpu.c:(.text+0x8f4): undefined reference to `do_cmd_list'
./libretro_ctr.a(gpulib_if.o): In function `renderer_sync_ecmds':
gpulib_if.cpp:(.text+0x247f0): undefined reference to `do_cmd_list'
collect2: error: ld returned 1 exit status
make: *** [Makefile.ctr:253: retroarch_3ds.elf] Error 1
make: Leaving directory '/mnt/data/dev/libretro/libretro-super/retroarch'
➜  dist-scripts git:(master) ✗ 
```

This PR should remedy the error shown above.
```
/opt/devkitpro/devkitARM/bin/arm-none-eabi-g++ -specs=ctr/3dsx_custom.specs -g -march=armv6k -mtune=mpcore -mfloat-abi=hard -marm -mfpu=vfp -mtp=soft -Wl,-Map,.map  gfx/drivers/ctr_shaders/ctr_sprite.o ctr/ctr_system.o ctr/ctr_memory.o ctr/ctr_linear.o ctr/gpu_old.o ctr/exec-3dsx/exec_cia.o ctr/exec-3dsx/exec_3dsx.o ctr/exec-3dsx/mini-hb-menu/launch.o ctr/exec-3dsx/mini-hb-menu/loaders/rosalina.o ctr/exec-3dsx/mini-hb-menu/loaders/hax2.o ctr/exec-3dsx/mini-hb-menu/loaders/ninjhax1.o ctr/ctr_svchax.o griffin/griffin.o -L. -L/opt/devkitpro/libctru/lib  -lretro_ctr  -lm -lctru -o retroarch_3ds.elf
/opt/devkitpro/devkitARM/bin/arm-none-eabi-nm -CSn retroarch_3ds.elf > .lst
rm -f retroarch_3ds.xml
pkg/ctr/tools/makerom-linux -f cia -o retroarch_3ds.cia -rsf pkg/ctr/tools/template.rsf -exefslogo -elf retroarch_3ds.elf -icon retroarch_3ds.icn -banner retroarch_3ds.bnr -DAPP_TITLE="PCSX ReARMed" -DAPP_PRODUCT_CODE="RARCH-PCSXRARMD" -DAPP_UNIQUE_ID=0xBAC15 -DAPP_SYSTEM_MODE=64MB -DAPP_SYSTEM_MODE_EXT=124MB -DAPP_ENCRYPTED=false
/opt/devkitpro/devkitARM/bin/3dsxtool retroarch_3ds.elf retroarch_3ds.3dsx 
make: Leaving directory '/mnt/data/dev/libretro/libretro-super/retroarch'
mv: cannot stat '../retroarch_3ds.3ds': No such file or directory
➜  dist-scripts git:(master) ✗ 
```
Despite the "mv: cannot stat '../retroarch_3ds.3ds': No such file or directory", .cia and .3dsx files for retroarch and pcsx_rearmed_libretro are created successfully under **<retroarch_repo>/pkg/ctr/build** which are the same files we have in builbot anyways.

i'd left gpu_unai disabled and would suggest a separate build instead similar to ios' interpreter build so as to easily switch between the gpu when needed and monitor properly if despite lower graphics quality-if it can perform any faster on non-neon, arm devices. (a better looking gpu_unai is available on the pcsx4all which can be easily ported and used-at least on linux as non-arm build, if we need improvements of the gpu)
