### PR TITLE
(BuildFix) Do not leave HAVE_NEON unset in armv platform check

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -285,7 +285,9 @@ else ifeq ($(platform), classic_armv7_a7)
 else ifneq (,$(findstring armv,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
+	HAVE_NEON = 0
 	DRC_CACHE_BASE = 0
+	BUILTIN_GPU = peops
 	ifneq (,$(findstring cortexa8,$(platform)))
 		CFLAGS += -marm -mcpu=cortex-a8
 		ASFLAGS += -mcpu=cortex-a8


### PR DESCRIPTION
* Default to `HAVE_NEON=0` until the `platform` is checked for `neon`
* Fixes build with `platform=armv` alone (no NEON requested) in a NEON device where the autodetection using `$(CC) -E -dD` will enable it

This happens in a chroot cross-compile environment such as in the RetroPie binary builder.
Edit: this shouldn't affect any other platform/condition, including the buildbot.