### PR TITLE
Revert "Fix input not working in some games"

### DIFF
--- a/libpcsxcore/plugins.c
+++ b/libpcsxcore/plugins.c
@@ -30,7 +30,7 @@ static s64 cdOpenCaseTime = 0;
 
 GPUupdateLace         GPU_updateLace;
 GPUinit               GPU_init;
-GPUshutdown           GPU_shutdown;
+GPUshutdown           GPU_shutdown; 
 GPUconfigure          GPU_configure;
 GPUtest               GPU_test;
 GPUabout              GPU_about;
@@ -39,7 +39,7 @@ GPUclose              GPU_close;
 GPUreadStatus         GPU_readStatus;
 GPUreadData           GPU_readData;
 GPUreadDataMem        GPU_readDataMem;
-GPUwriteStatus        GPU_writeStatus;
+GPUwriteStatus        GPU_writeStatus; 
 GPUwriteData          GPU_writeData;
 GPUwriteDataMem       GPU_writeDataMem;
 GPUdmaChain           GPU_dmaChain;
@@ -55,7 +55,7 @@ GPUvBlank             GPU_vBlank;
 CDRinit               CDR_init;
 CDRshutdown           CDR_shutdown;
 CDRopen               CDR_open;
-CDRclose              CDR_close;
+CDRclose              CDR_close; 
 CDRtest               CDR_test;
 CDRgetTN              CDR_getTN;
 CDRgetTD              CDR_getTD;
@@ -124,7 +124,7 @@ PADsetSensitive       PAD2_setSensitive;
 NETinit               NET_init;
 NETshutdown           NET_shutdown;
 NETopen               NET_open;
-NETclose              NET_close;
+NETclose              NET_close; 
 NETtest               NET_test;
 NETconfigure          NET_configure;
 NETabout              NET_about;
@@ -143,7 +143,7 @@ NETkeypressed         NET_keypressed;
 SIO1init              SIO1_init;
 SIO1shutdown          SIO1_shutdown;
 SIO1open              SIO1_open;
-SIO1close             SIO1_close;
+SIO1close             SIO1_close; 
 SIO1test              SIO1_test;
 SIO1configure         SIO1_configure;
 SIO1about             SIO1_about;
@@ -218,9 +218,9 @@ static int LoadGPUplugin(const char *GPUdll) {
 	void *drv;
 
 	hGPUDriver = SysLoadLibrary(GPUdll);
-	if (hGPUDriver == NULL) {
+	if (hGPUDriver == NULL) { 
 		GPU_configure = NULL;
-		SysMessage (_("Could not load GPU plugin %s!"), GPUdll); return -1;
+		SysMessage (_("Could not load GPU plugin %s!"), GPUdll); return -1; 
 	}
 	drv = hGPUDriver;
 	LoadGpuSym1(init, "GPUinit");
@@ -351,7 +351,7 @@ static int LoadSPUplugin(const char *SPUdll) {
 	LoadSpuSym0(about, "SPUabout");
 	LoadSpuSym0(test, "SPUtest");
 	LoadSpuSym1(writeRegister, "SPUwriteRegister");
-	LoadSpuSym1(readRegister, "SPUreadRegister");
+	LoadSpuSym1(readRegister, "SPUreadRegister");		
 	LoadSpuSym1(writeDMA, "SPUwriteDMA");
 	LoadSpuSym1(readDMA, "SPUreadDMA");
 	LoadSpuSym1(writeDMAMem, "SPUwriteDMAMem");
@@ -378,19 +378,19 @@ static int reqPos, respSize, req;
 static int ledStateReq44[8];
 
 static unsigned char buf[256];
-static unsigned char bufMulti[34] = { 0x80, 0x5a,
+static unsigned char bufMulti[34] = { 0x80, 0x5a, 
 									0x41, 0x5a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 									0x41, 0x5a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 									0x41, 0x5a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 									0x41, 0x5a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-
+									
 unsigned char stdpar[8] = { 0x41, 0x5a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-unsigned char multitappar[34] = { 0x80, 0x5a,
+unsigned char multitappar[34] = { 0x80, 0x5a, 
 									0x41, 0x5a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 									0x41, 0x5a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 									0x41, 0x5a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
 									0x41, 0x5a, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
-
+									
 //response for request 44, 45, 46, 47, 4C, 4D
 static unsigned char resp45[8]    = {0xF3, 0x5A, 0x01, 0x02, 0x00, 0x02, 0x01, 0x00};
 static unsigned char resp46_00[8] = {0xF3, 0x5A, 0x00, 0x00, 0x01, 0x02, 0x00, 0x0A};
@@ -423,26 +423,26 @@ enum {
 	// AA rumble large motor speed 0x00 -> 0xFF
 	// RESPONSE
 	// header 3 Bytes
-	// 0x00
-	// PadId -> 0x41 for digital pas, 0x73 for analog pad
+	// 0x00 
+	// PadId -> 0x41 for digital pas, 0x73 for analog pad 
 	// 0x5A mode has not change (no press on analog button on the center of pad), 0x00 the analog button have been pressed and the mode switch
 	// 6 Bytes for keystates
 	CMD_READ_DATA_AND_VIBRATE = 0x42,
-
+	
 	// REQUEST
 	// Header
 	// 0x0N, 0x43, 0x00, XX, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	// XX = 00 -> Normal mode : Seconde bytes of response = padId
 	// XX = 01 -> Configuration mode : Seconde bytes of response = 0xF3
 	// RESPONSE
-	// enter in config mode example :
+	// enter in config mode example : 
 	// req : 01 43 00 01 00 00 00 00 00 00
 	// res : 00 41 5A buttons state, analog states
-	// exit config mode :
+	// exit config mode : 
 	// req : 01 43 00 00 00 00 00 00 00 00
 	// res : 00 F3 5A buttons state, analog states
 	CMD_CONFIG_MODE = 0x43,
-
+	
 	// Set led State
 	// REQUEST
 	// 0x0N, 0x44, 0x00, VAL, SEL, 0x00, 0x00, 0x00, 0x00
@@ -452,7 +452,7 @@ enum {
 	// RESPONSE
 	// 0x00, 0xF3, 0x5A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	CMD_SET_MODE_AND_LOCK = 0x44,
-
+	
 	// Get Analog Led state
 	// REQUEST
 	// 0x0N, 0x45, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
@@ -461,7 +461,7 @@ enum {
 	// VAL = 00 Led OFF
 	// VAL = 01 Led ON
 	CMD_QUERY_MODEL_AND_MODE = 0x45,
-
+	
 	//Get Variable A
 	// REQUEST
 	// 0x0N, 0x46, 0x00, 0xXX, 0x00, 0x00, 0x00, 0x00, 0x00
@@ -471,13 +471,13 @@ enum {
 	// XX=01
 	// 0x00, 0xF3, 0x5A, 0x00, 0x00, 0x01, 0x01, 0x01, 0x14
 	CMD_QUERY_ACT = 0x46,
-
+	
 	// REQUEST
 	// 0x0N, 0x47, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	// RESPONSE
 	// 0x00, 0xF3, 0x5A, 0x00, 0x00, 0x02, 0x00, 0x01, 0x00
 	CMD_QUERY_COMB = 0x47,
-
+	
 	// REQUEST
 	// 0x0N, 0x4C, 0x00, 0xXX, 0x00, 0x00, 0x00, 0x00, 0x00
 	// RESPONSE
@@ -486,7 +486,7 @@ enum {
 	// XX = 1
 	// 0x00, 0xF3, 0x5A, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00
 	CMD_QUERY_MODE = 0x4C,
-
+	
 	// REQUEST
 	// 0x0N, 0x4D, 0x00, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF
 	// RESPONSE
@@ -507,16 +507,20 @@ enum {
 	REQ4F = 0x4F
 };
 
+
+
+
 //NO MULTITAP
 
-static void initBufForRequest(int padIndex, char value) {
-	switch (value) {
+void initBufForRequest(int padIndex, char value){
+	switch (value){
 		//Pad keystate already in buffer
 		//case CMD_READ_DATA_AND_VIBRATE :
 		//	break;
 		case CMD_CONFIG_MODE :
 			if (pad[padIndex].configMode == 1) {
 				memcpy(buf, resp43, 8);
+				break;
 			}
 			//else, not in config mode, pad keystate return (already in the buffer)
 			break;
@@ -562,8 +566,11 @@ static void initBufForRequest(int padIndex, char value) {
 	}
 }
 
-static void reqIndex2Treatment(int padIndex, char value) {
-	switch (value) {
+
+
+
+void reqIndex2Treatment(int padIndex, char value){
+	switch (req){
 		case CMD_CONFIG_MODE :
 			//0x43
 			if (value == 0) {
@@ -599,8 +606,8 @@ static void reqIndex2Treatment(int padIndex, char value) {
 			break;
 	}
 }
-
-void vibrate(int padIndex) {
+	
+void vibrate(int padIndex){
 	if (pad[padIndex].Vib[0] != pad[padIndex].VibF[0] || pad[padIndex].Vib[1] != pad[padIndex].VibF[1]) {
 		//value is different update Value and call libretro for vibration
 		pad[padIndex].VibF[0] = pad[padIndex].Vib[0];
@@ -609,6 +616,9 @@ void vibrate(int padIndex) {
 		//printf("vibration pad %i", padIndex);
 	}
 }
+
+
+
 
 //Build response for 0x42 request Pad in port
 void _PADstartPoll(PadDataS *pad) {
@@ -670,18 +680,20 @@ void _PADstartPoll(PadDataS *pad) {
     }
 }
 
+
 //Build response for 0x42 request Multitap in port
 //Response header for multitap : 0x80, 0x5A, (Pad information port 1-2A), (Pad information port 1-2B), (Pad information port 1-2C), (Pad information port 1-2D)
 void _PADstartPollMultitap(PadDataS* padd) {
-	int i, offset;
-	for(i = 0; i < 4; i++) {
-		offset = 2 + (i * 8);
-		_PADstartPoll(&padd[i]);
-		memcpy(multitappar+offset, stdpar, 8);
-	}
-	memcpy(bufMulti, multitappar, 34);
-	respSize = 34;
+    int i, offset;
+    for(i = 0; i < 4; i++) {
+    	offset = 2 + (i * 8);
+	_PADstartPoll(&padd[i]);
+	memcpy(multitappar+offset, stdpar, 8);
+    }
+    memcpy(bufMulti, multitappar, 34);
+    respSize = 34;
 }
+
 
 unsigned char _PADpoll(int port, unsigned char value) {
 	if (reqPos == 0) {
@@ -690,11 +702,11 @@ unsigned char _PADpoll(int port, unsigned char value) {
 		//copy the default value of request response in buffer instead of the keystate
 		initBufForRequest(port, value);
 	}
-
+	
 	//if no new request the pad return 0xff, for signaling connected
 	if (reqPos >= respSize) return 0xff;
-
-	switch(reqPos) {
+	
+	switch(reqPos){
 		case 2:
 			reqIndex2Treatment(port, value);
 		break;
@@ -715,12 +727,12 @@ unsigned char _PADpoll(int port, unsigned char value) {
 	return buf[reqPos++];
 }
 
-unsigned char _PADpollMultitap(int port, unsigned char value) {
-	if (reqPos >= respSize)
-		return 0xff;
 
+unsigned char _PADpollMultitap(int port, unsigned char value) {
+	if (reqPos >= respSize) return 0xff;
 	return bufMulti[reqPos++];
 }
+
 
 // refresh the button state on port 1.
 // int pad is not needed.
@@ -762,8 +774,9 @@ unsigned char CALLBACK PAD1__poll(unsigned char value) {
 	}
 	//printf("%2x:%2x, ",value,tmp);
 	return tmp;
-
+	
 }
+
 
 long CALLBACK PAD1__configure(void) { return 0; }
 void CALLBACK PAD1__about(void) {}
@@ -826,7 +839,7 @@ unsigned char CALLBACK PAD2__startPoll(int pad) {
 		PAD2_readPort2(&padd);
 		multitap2 = padd.portMultitap;
 	}
-
+	
 	// just one pad is on port 1 : NO MULTITAP
 	if (multitap2 == 0) {
 		PadDataS padd;
@@ -1126,7 +1139,7 @@ void ReleasePlugins() {
 	if (hPAD1Driver != NULL) PAD1_shutdown();
 	if (hPAD2Driver != NULL) PAD2_shutdown();
 
-	if (Config.UseNet && hNETDriver != NULL) NET_shutdown();
+	if (Config.UseNet && hNETDriver != NULL) NET_shutdown(); 
 
 	if (hCDRDriver != NULL) SysCloseLibrary(hCDRDriver); hCDRDriver = NULL;
 	if (hGPUDriver != NULL) SysCloseLibrary(hGPUDriver); hGPUDriver = NULL;


### PR DESCRIPTION
Reverts libretro/pcsx_rearmed#262

this is incorrect. causes missing rumble and KoroKoro does not support analog.
newer PR will be sent soon unless someone beats me to it.

reopen the related bounty source post for this: https://github.com/libretro/pcsx_rearmed/issues/161