### PR TITLE
Backport check for Thumb instructions from configure script

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -47,6 +47,12 @@ ifeq ($(platform), unix)
 ifneq ($(findstring SunOS,$(shell uname -s)),)
 	CC = gcc
 endif
+ifeq ($(ARCH), arm)
+ifneq ($(findstring __thumb__,$(shell $(CC) -E -dD $(CFLAGS) include/arm_features.h)),)
+	# must disable thumb as recompiler can't handle it
+	CFLAGS += -marm
+endif
+endif
 
 else ifeq ($(platform), linux-portable)
 	TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
The recompiler can't handle Thumb instructions, so they must be disabled.
This is accomplished via the `-marm` flag being set for different platforms.

However, when using `platform=unix` and manually configuring the build, the check for Thumb instructions is not done in `Makefile.libretro`. Therefore, when building with a compiler that defaults to Thumb instructions (e.g. ODROID-XU4), the build can fail with this error:

    libpcsxcore/new_dynarec/backends/psx/pcsxmem.c:18:2: error:
     #error the dynarec is incompatible with Thumb functions,
    libpcsxcore/new_dynarec/backends/psx/pcsxmem.c:19:2: error:
     #error please add -marm to compile flags

To address this, we simply backport the define check from the configure script for when we build with `ARCH=arm`. This change doesn't affect the buildbot.

Example of manual building with a compilar that defaults to Thumb, where this PR is necessary:

    make -f Makefile.libretro ARCH=arm USE_DYNAREC=1 HAVE_NEON=1 BUILTIN_GPU=neon

