### PR TITLE
Fix CHD build for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,7 @@ OBJS += deps/libchdr/flac.o
 OBJS += deps/libchdr/huffman.o
 
 ifneq (,$(findstring win,$(platform)))
+  CFLAGS += -DHAVE_FSEEKO
   OBJS += deps/flac-1.3.2/src/libFLAC/windows_unicode_filenames.o
 else
   CFLAGS += -DHAVE_SYS_PARAM_H


### PR DESCRIPTION
buildbot log http://p.0bl.net/123526

```
cc  -DGIT_VERSION=\"" 4b7520c"\" -D__WIN32__ -DNO_DYLIB  -D_FILE_OFFSET_BITS=64 -Wall -Iinclude -ffast-math -O2 -DNDEBUG -Ideps/zlib -Ideps/libchdr -Ideps/crypto -Ideps/flac-1.3.2/include -Ideps/flac-1.3.2/src/libFLAC/include -Ideps/flac-1.3.2/src/libFLAC/include -Ideps/lzma-16.04/C -D'PACKAGE_VERSION="1.3.2"' -DFLAC__HAS_OGG=0 -DFLAC__NO_DLL -DHAVE_LROUND -DHAVE_STDINT_H -DHAVE_STDLIB_H -DFLAC__NO_DLL -D_7ZIP_ST -DFRONTEND_SUPPORTS_RGB565 -DHAVE_LIBRETRO -DNO_FRONTEND -c -o deps/flac-1.3.2/src/libFLAC/bitmath.o deps/flac-1.3.2/src/libFLAC/bitmath.c
In file included from deps/flac-1.3.2/src/libFLAC/include/private/bitmath.h:39,
                 from deps/flac-1.3.2/src/libFLAC/bitmath.c:37:
deps/flac-1.3.2/include/share/compat.h:57:16: error: conflicting types for 'fseeko64'
 #define fseeko fseeko64
                ^~~~~~~~
In file included from deps/flac-1.3.2/include/share/win_utf8_io.h:37,
                 from deps/flac-1.3.2/include/share/compat.h:150,
                 from deps/flac-1.3.2/src/libFLAC/include/private/bitmath.h:39,
                 from deps/flac-1.3.2/src/libFLAC/bitmath.c:37:
D:/msys64/mingw64/x86_64-w64-mingw32/include/stdio.h:628:7: note: previous declaration of 'fseeko64' was here
   int fseeko64(FILE* stream, _off64_t offset, int whence);
       ^~~~~~~~
D:/msys64/mingw64/x86_64-w64-mingw32/include/stdio.h:632:12: error: conflicting types for 'ftello64'
   _off64_t ftello64(FILE * stream);
            ^~~~~~~~
In file included from deps/flac-1.3.2/src/libFLAC/include/private/bitmath.h:39,
                 from deps/flac-1.3.2/src/libFLAC/bitmath.c:37:
deps/flac-1.3.2/include/share/compat.h:58:16: note: previous declaration of 'ftello64' was here
 #define ftello ftello64
                ^~~~~~~~
make: *** [Makefile:332: deps/flac-1.3.2/src/libFLAC/bitmath.o] Error 1
```