### PR TITLE
Allow building without CHD, disable CHD for 3DS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,6 +159,7 @@ endif
 OBJS += plugins/cdrcimg/cdrcimg.o
 
 # libchdr
+ifeq "$(HAVE_CHD)" "1"
 CFLAGS += -Ideps/libchdr
 OBJS += deps/crypto/md5.o
 OBJS += deps/crypto/sha1.o
@@ -208,8 +209,9 @@ else
 endif
 
 CFLAGS += -Ideps/crypto -Ideps/flac-1.3.2/include -Ideps/flac-1.3.2/src/libFLAC/include -Ideps/flac-1.3.2/src/libFLAC/include -Ideps/lzma-16.04/C
-CFLAGS += -D'PACKAGE_VERSION="1.3.2"' -DFLAC__HAS_OGG=0 -DFLAC__NO_DLL -DHAVE_LROUND -DHAVE_STDINT_H -DHAVE_STDLIB_H -DFLAC__NO_DLL -D_7ZIP_ST
+CFLAGS += -DHAVE_CHD -D'PACKAGE_VERSION="1.3.2"' -DFLAC__HAS_OGG=0 -DFLAC__NO_DLL -DHAVE_LROUND -DHAVE_STDINT_H -DHAVE_STDLIB_H -DFLAC__NO_DLL -D_7ZIP_ST
 LDFLAGS += -lm
+endif
 
 # dfinput
 OBJS += plugins/dfinput/main.o plugins/dfinput/pad.o plugins/dfinput/guncon.o

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -2,6 +2,7 @@
 
 DEBUG ?= 0
 WANT_ZLIB ?= 1
+HAVE_CHD ?= 1
 
 ifeq ($(platform),)
 	platform = unix
@@ -188,7 +189,7 @@ else ifeq ($(platform), ctr)
 	DRC_CACHE_BASE = 0
 	ARCH = arm
 	HAVE_NEON = 0
-
+	HAVE_CHD = 0
 	STATIC_LINKING = 1
 
 # Xbox 360


### PR DESCRIPTION
- all platforms compiles with CHD support.
- compile with HAVE_CHD=0 for no chd support.
- CHD fails building for 3DS, not sure its even fast enough for the device. I tried asking in discord channel but haven't got reply. Disabling it till someone familiar with 3ds can fix it.
http://p.0bl.net/123458