### PR TITLE
Fix neGcon input

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1823,7 +1823,7 @@ void retro_run(void)
 			// Query digital inputs
 			//
 			// > Pad-Up
-			if (ret & (1 < RETRO_DEVICE_ID_JOYPAD_UP))
+			if (ret & (1 << RETRO_DEVICE_ID_JOYPAD_UP))
 				in_keystate[i] |= (1 << DKEY_UP);
 			// > Pad-Right
 			if (ret & (1 << RETRO_DEVICE_ID_JOYPAD_RIGHT))


### PR DESCRIPTION
When the bitmask input code was added, a little typo broke dpad up when using neGcon input devices.

This trivial PR fixes the issue.