### PR TITLE
psxhle.c: Silence logging when using HLE bios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -337,13 +337,11 @@ frontend/revision.h: FORCE
 target_: $(TARGET)
 
 $(TARGET): $(OBJS)
-	@echo "** BUILDING $(TARGET) FOR PLATFORM $(PLATFORM) **"
 ifeq ($(STATIC_LINKING), 1)
 	$(AR) rcs $@ $(OBJS)
 else
 	$(CC_LINK) -o $@ $^ $(LDFLAGS) $(LDLIBS) $(EXTRA_LDFLAGS)
 endif
-	@echo "** BUILD SUCCESSFUL! GG NO RE **"
 
 clean: $(PLAT_CLEAN) clean_plugins
 	$(RM) $(TARGET) $(OBJS) $(TARGET).map frontend/revision.h

--- a/libpcsxcore/psxhle.c
+++ b/libpcsxcore/psxhle.c
@@ -23,6 +23,12 @@
 
 #include "psxhle.h"
 
+#if 0
+#define PSXHLE_LOG SysPrintf
+#else
+#define PSXHLE_LOG(...)
+#endif
+
 static void hleDummy() {
 	psxRegs.pc = psxRegs.GPR.n.ra;
 
@@ -54,10 +60,10 @@ static void hleC0() {
 }
 
 static void hleBootstrap() { // 0xbfc00000
-	SysPrintf("hleBootstrap\n");
+	PSXHLE_LOG("hleBootstrap\n");
 	CheckCdrom();
 	LoadCdrom();
-	SysPrintf("CdromLabel: \"%s\": PC = %8.8lx (SP = %8.8lx)\n", CdromLabel, psxRegs.pc, psxRegs.GPR.n.sp);
+	PSXHLE_LOG("CdromLabel: \"%s\": PC = %8.8lx (SP = %8.8lx)\n", CdromLabel, psxRegs.pc, psxRegs.GPR.n.sp);
 }
 
 typedef struct {                   
@@ -77,7 +83,7 @@ typedef struct {
 static void hleExecRet() {
 	EXEC *header = (EXEC*)PSXM(psxRegs.GPR.n.s0);
 
-	SysPrintf("ExecRet %x: %x\n", psxRegs.GPR.n.s0, header->ret);
+	PSXHLE_LOG("ExecRet %x: %x\n", psxRegs.GPR.n.s0, header->ret);
 
 	psxRegs.GPR.n.ra = header->ret;
 	psxRegs.GPR.n.sp = header->_sp;


### PR DESCRIPTION
- at least one game (Wild Arms) is continouosly spamming the log window. Silence this in a way that its easy to enable when need to.
- Remove unnecessary message in Makefile