### PR TITLE
Fix main RAM size in retro_get_memory_size

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1323,7 +1323,7 @@ size_t retro_get_memory_size(unsigned id)
 	if (id == RETRO_MEMORY_SAVE_RAM)
 		return MCD_SIZE;
 	else if (id == RETRO_MEMORY_SYSTEM_RAM)
-		return 0x210000;
+		return 0x200000;
 	else
 		return 0;
 }


### PR DESCRIPTION
PSX Main RAM should only by 2048KB