### PR TITLE
Do not compile plugins when using the non-static build method

### DIFF
--- a/configure
+++ b/configure
@@ -550,12 +550,15 @@ echo >> $config_mak
 
 if [ "$platform" = "libretro" ]; then
   echo "TARGET = libretro.so" >> $config_mak
+  echo "HAVE_CHD = 1" >> $config_mak
 fi
 echo "ARCH = $ARCH" >> $config_mak
 echo "PLATFORM = $platform" >> $config_mak
 echo "BUILTIN_GPU = $builtin_gpu" >> $config_mak
 echo "SOUND_DRIVERS = $sound_drivers" >> $config_mak
-echo "PLUGINS = $plugins" >> $config_mak
+if [ "$platform" != "libretro" ]; then
+  echo "PLUGINS = $plugins" >> $config_mak
+fi
 if [ "$have_arm_neon" = "yes" ]; then
   echo "HAVE_NEON = 1" >> $config_mak
 fi


### PR DESCRIPTION
- This is meant for platforms that still uses the non-static build method to compile the libretro core (aka versions of retropie)
- The output file is still libretro.so to preserve any compatibility with existing script
- Using the static makefile is still recommended.

reference: https://github.com/libretro/pcsx_rearmed/issues/329