### PR TITLE
Added support for PSXONPSP660.bin and psx* named BIOS files

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -2078,7 +2078,7 @@ static bool find_any_bios(const char *dirpath, char *path, size_t path_size)
 		return false;
 
 	while ((ent = readdir(dir))) {
-		if (strncasecmp(ent->d_name, "scph", 4) != 0)
+		if ((strncasecmp(ent->d_name, "scph", 4) != 0) && (strncasecmp(ent->d_name, "psx", 3) != 0))
 			continue;
 
 		snprintf(path, path_size, "%s%c%s", dirpath, SLASH, ent->d_name);
@@ -2144,6 +2144,7 @@ static void loadPSXBios(void)
 	unsigned useHLE = 0;
 
 	const char *bios[] = {
+		"PSXONPSP660", "psxonpsp660",
 		"SCPH101", "scph101",
 		"SCPH5501", "scph5501",
 		"SCPH7001", "scph7001",


### PR DESCRIPTION
This allows you to use the PSXONPSP660.bin "optimized" PSP PSX BIOS that is being circulated online. See https://forums.libretro.com/t/psx-bios-from-psp-6-60-optimised-to-play-games-more-smoothly-but-how and libretro/beetle-psx-libretro#519

I don't know if there's any particular naming convention to this BIOS, so I have additionally added psx* to search in find_any_bios(). It shouldn't really be called scph*, though, since the BIOS is not from actual playstation hardware.