### PR TITLE
(iOS/tvOS) fix target for iOS/tvOS: remove _interpreter since dynarec…

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -77,16 +77,31 @@ ifeq ($(USE_DYNAREC),0)
 endif
 
 # iOS
-else ifeq ($(platform),$(filter $(platform),ios-arm64))
+else ifeq ($(platform), ios-arm64)
+	fpic := -fPIC
+	ifeq ($(IOSSDK),)
+		IOSSDK := $(shell xcodebuild -version -sdk iphoneos Path)
+        endif
 	ARCH := arm64
 	USE_DYNAREC = 0
 	HAVE_NEON = 0
 	BUILTIN_GPU = peops
-	TARGET := $(TARGET_NAME)_interpreter_libretro_ios.dylib
+	TARGET := $(TARGET_NAME)_libretro_ios.dylib
 
 	CC = clang -arch arm64 -isysroot $(IOSSDK) -miphoneos-version-min=8.0
 	CXX = clang++ -arch arm64 -isysroot $(IOSSDK) -miphoneos-version-min=8.0
 	CFLAGS += -marm -DIOS
+
+else ifeq ($(platform), tvos-arm64)
+	ARCH := arm64
+	USE_DYNAREC = 0
+	HAVE_NEON = 0
+	BUILTIN_GPU = peops
+        ifeq ($(IOSSDK),)
+                IOSSDK := $(shell xcodebuild -version -sdk appletvos Path)
+        endif
+	TARGET := $(TARGET_NAME)_libretro_tvos.dylib
+	CFLAGS += -marm -DIOS -DIOS_TVOS
 
 else ifneq (,$(findstring ios,$(platform)))
 	ARCH := arm

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -12,7 +12,9 @@
 #include <strings.h>
 #ifdef __MACH__
 #include <unistd.h>
+#ifndef IOS_TVOS
 #include <sys/syscall.h>
+#endif
 #endif
 
 #include "../libpcsxcore/misc.h"
@@ -2203,8 +2205,10 @@ void retro_init(void)
 	int ret;
 
 #ifdef __MACH__
+#ifndef IOS_TVOS
 	// magic sauce to make the dynarec work on iOS
 	syscall(SYS_ptrace, 0 /*PTRACE_TRACEME*/, 0, 0, 0);
+#endif
 #endif
 
 #ifdef _3DS


### PR DESCRIPTION
… on iOS is dependent on jailbreaking, and jailbreaking does not guarantee dynarec; add conditional around syscall since its not allowed on tvOS