### PR TITLE
Fix sound over-buffering on 3ds

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -144,7 +144,7 @@ void emu_set_default_config(void)
 	spu_config.iVolume = 768;
 	spu_config.iTempo = 0;
 	spu_config.iUseThread = 1; // no effect if only 1 core is detected
-#ifdef HAVE_PRE_ARMV7 /* XXX GPH hack */
+#if defined(HAVE_PRE_ARMV7) && !defined(_3DS) /* XXX GPH hack */
 	spu_config.iUseReverb = 0;
 	spu_config.iUseInterpolation = 0;
 	spu_config.iTempo = 1;


### PR DESCRIPTION
With iTempo turned on, we generate a frame and a half of sound data each frame, which causes dropped sound frames and noise.

It looks like GPH hacks are disabled for 3ds in other places, so disabling it here too seemed like the correct fix.