### PR TITLE
Enable CHD on 3DS builds

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -193,7 +193,6 @@ else ifeq ($(platform), ctr)
 	DRC_CACHE_BASE = 0
 	ARCH = arm
 	HAVE_NEON = 0
-	HAVE_CHD = 0
 	STATIC_LINKING = 1
 
 # Xbox 360


### PR DESCRIPTION
I don't know what build errors were happening before, but this built cleanly for me. I tested on a few CHDs and it loads them just fine -- in fact, it seems like they run much faster than bin/cue. I couldn't get m3us referencing CHDs to load, though -- is that expected?