### PR TITLE
Stop calling utime on 3ds

### DIFF
--- a/deps/flac-1.3.2/src/libFLAC/metadata_iterators.c
+++ b/deps/flac-1.3.2/src/libFLAC/metadata_iterators.c
@@ -3430,7 +3430,10 @@ void set_file_stats_(const char *filename, struct flac_stat_s *stats)
 	srctime.actime = stats->st_atime;
 	srctime.modtime = stats->st_mtime;
 	(void)flac_chmod(filename, stats->st_mode);
+#if !defined _3DS
 	(void)flac_utime(filename, &srctime);
+#endif
+
 #if !defined _MSC_VER && !defined __BORLANDC__ && !defined __MINGW32__
 	FLAC_CHECK_RETURN(chown(filename, stats->st_uid, -1));
 	FLAC_CHECK_RETURN(chown(filename, -1, stats->st_gid));

--- a/deps/flac-1.3.2/src/share/grabbag/file.c
+++ b/deps/flac-1.3.2/src/share/grabbag/file.c
@@ -58,7 +58,9 @@ void grabbag__file_copy_metadata(const char *srcpath, const char *destpath)
 		srctime.actime = srcstat.st_atime;
 		srctime.modtime = srcstat.st_mtime;
 		(void)flac_chmod(destpath, srcstat.st_mode);
+#if !defined _3DS
 		(void)flac_utime(destpath, &srctime);
+#endif
 	}
 }
 


### PR DESCRIPTION
The toolchain doesn't have utime defined, so these calls will fail.