### PR TITLE
3DS: Schedule threads on the default core

### DIFF
--- a/frontend/3ds/pthread.h
+++ b/frontend/3ds/pthread.h
@@ -25,7 +25,7 @@ static inline int pthread_create(pthread_t *thread,
 
    svcCreateThread(&thread->handle, start_routine, arg,
                    (uint32_t*)((uint32_t)thread->stack + CTR_PTHREAD_STACK_SIZE),
-                   0x25, 1);
+                   0x25, -2);
 
    return 1;
 }


### PR DESCRIPTION
When creating a thread, pcsx was scheduling threads on core 1, which is the system core. This is usually prevented by the system. Instead, it should schedule threads on the default core, as suggested by 3dbrew: https://www.3dbrew.org/wiki/Multi-threading

> Games usually create threads using -2.

In the future, we may be able to schedule threads on core 2 on New 3DS only, if we find it gives better performance.

This was preventing the CDDA thread from starting, which was preventing CD Audio from playing.