### PR TITLE
Add "Spu Irq" core option

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1614,6 +1614,16 @@ static void update_variables(bool in_flight)
          Config.Cdda = 0;
    }
 
+   var.value = NULL;
+   var.key = "pcsx_rearmed_spuirq";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || var.value)
+   {
+      if (strcmp(var.value, "disabled") == 0)
+         Config.SpuIrq = 0;
+      else
+         Config.SpuIrq = 1;
+   }
+
 #ifndef DRC_DISABLE
    var.value = NULL;
    var.key = "pcsx_rearmed_nosmccheck";

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -970,6 +970,17 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "enabled",
    },
+   {
+      "pcsx_rearmed_spuirq",
+      "SPU IRQ Always Enabled",
+      "Compatibility tweak, should be left to off in most cases.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
+   },
 
 #ifndef DRC_DISABLE
    {


### PR DESCRIPTION
Adds the "Spu Irq" advance options to core menu.

Fix https://github.com/libretro/pcsx_rearmed/issues/359