### PR TITLE
Add input analog axis range modifier

### DIFF
--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -267,6 +267,17 @@ struct retro_core_option_definition option_defs_us[] = {
       "linear",
    },
    {
+      "pcsx_rearmed_analog_axis_modifier",
+      "Analog axis bounds.",
+      "Range bounds for analog axis. Square bounds help controllers with highly circular ranges that are unable to fully saturate the x and y axis at 45degree deflections.",
+      {
+         { "circle", NULL },
+         { "square", NULL },
+         { NULL, NULL },
+      },
+      "circle",
+   },
+   {
       "pcsx_rearmed_vibration",
       "Enable Vibration",
       "Enables vibration feedback for controllers that supports vibration features.",


### PR DESCRIPTION
Add core option to change axis saturation. Square bounds allow controllers that struggle to fully register diagonal deflections . Very helpful with switch joycons and some android controllers.