### PR TITLE
Fix second instance runahead

### DIFF
--- a/libpcsxcore/lightrec/plugin.c
+++ b/libpcsxcore/lightrec/plugin.c
@@ -564,8 +564,10 @@ static void lightrec_plugin_shutdown(void)
 
 static void lightrec_plugin_reset(void)
 {
-	lightrec_plugin_shutdown();
-	lightrec_plugin_init();
+// Called in every frame (or every frame where input changes) when using runahead
+//	lightrec_plugin_shutdown();
+//	lightrec_plugin_init();
+	lightrec_invalidate_all(lightrec_state);
 }
 
 R3000Acpu psxRec =

--- a/libpcsxcore/psxmem.c
+++ b/libpcsxcore/psxmem.c
@@ -43,7 +43,11 @@ void *psxMap(unsigned long addr, size_t size, int is_fixed,
 		enum psxMapTag tag)
 {
 #ifdef LIGHTREC
+#ifdef MAP_FIXED_NOREPLACE
+	int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE;
+#else
 	int flags = MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED;
+#endif
 #else
 	int flags = MAP_PRIVATE | MAP_ANONYMOUS;
 #endif
@@ -142,6 +146,9 @@ int psxMemInit() {
 
 #ifdef LIGHTREC
 	psxM = psxMap(0x30000000, 0x00210000, 1, MAP_TAG_RAM);
+	if (psxM == NULL)
+		psxM = psxMap(0x70000000, 0x00210000, 1, MAP_TAG_RAM);
+
 #else
 	psxM = psxMap(0x80000000, 0x00210000, 1, MAP_TAG_RAM);
 #endif
@@ -157,7 +164,12 @@ int psxMemInit() {
 	psxP = &psxM[0x200000];
 #ifdef LIGHTREC
 	psxH = psxMap(0x4f800000, 0x10000, 0, MAP_TAG_OTHER);
+	if (psxH == NULL)
+		psxH = psxMap(0x8f800000, 0x10000, 0, MAP_TAG_OTHER);
+
 	psxR = psxMap(0x4fc00000, 0x80000, 0, MAP_TAG_OTHER);
+	if (psxR == NULL)
+		psxR = psxMap(0x8fc00000, 0x80000, 0, MAP_TAG_OTHER);
 #else
 	psxH = psxMap(0x1f800000, 0x10000, 0, MAP_TAG_OTHER);
 	psxR = psxMap(0x1fc00000, 0x80000, 0, MAP_TAG_OTHER);


### PR DESCRIPTION
Also prefer MAP_FIXED_NOREPLACE over MAP_FIXED, as it won't remove old memory maps

Fixes #382 

Tested to work on both Windows 10 64-bit and Linux