### PR TITLE
Fix dynarec crashes on 3DS

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -213,6 +213,8 @@ else ifeq ($(platform), ctr)
 	CFLAGS += -Ifrontend/3ds
 	CFLAGS += -Werror=implicit-function-declaration
 
+	OBJS += frontend/3ds/utils.o
+
 #	CFLAGS += -DPCSX
 	BUILTIN_GPU = unai
 	DYNAREC = ari64

--- a/frontend/3ds/utils.S
+++ b/frontend/3ds/utils.S
@@ -1,0 +1,25 @@
+  .text
+  .arm
+  .balign 4
+
+  .func ctr_clear_cache_kernel
+ctr_clear_cache_kernel:
+  cpsid aif
+  mov r0, #0
+  mcr p15, 0, r0, c7, c10, 0    @ Clean entire data cache
+  mcr p15, 0, r0, c7, c10, 5    @ Data Memory Barrier
+  mcr p15, 0, r0, c7, c5, 0     @ Invalidate entire instruction cache / Flush BTB
+  mcr p15, 0, r0, c7, c10, 4    @ Data Sync Barrier
+  bx lr
+  .endfunc
+
+  @@ Clear the entire data cache / invalidate the instruction cache. Uses
+  @@ Rosalina svcCustomBackdoor to avoid svcBackdoor stack corruption
+  @@ during interrupts.
+  .global ctr_clear_cache
+  .func ctr_clear_cache
+ctr_clear_cache:
+  ldr r0, =ctr_clear_cache_kernel
+  svc 0x80                      @ svcCustomBackdoor
+  bx lr
+  .endfunc

--- a/libpcsxcore/new_dynarec/new_dynarec.c
+++ b/libpcsxcore/new_dynarec/new_dynarec.c
@@ -7085,6 +7085,10 @@ void new_dynarec_init(void)
 {
   SysPrintf("Init new dynarec\n");
 
+#ifdef _3DS
+  check_rosalina();
+#endif
+
   // allocate/prepare a buffer for translation cache
   // see assem_arm.h for some explanation
 #if   defined(BASE_ADDR_FIXED)


### PR DESCRIPTION
After the dynarec writes new instructions, it has to flush the instruction and data caches. Some of these flush operations are privileged on the 3DS, so the clear cache functions have to run
through svcBackdoor. The Nintendo implementation (and CFW reimplementation) of svcBackdoor has a problem where interrupts and context switches will cause crashes. See [here](https://github.com/AuroraWright/Luma3DS/blob/master/k11_extension/source/svc/Backdoor.s#L39) for a note on this.

Even though we can disable interrupts in the flush function, there's a window of time between svcBackdoor being called and the function being run where an interrupt will corrupt the stack. Most of the time, svcBackdoor is just used for setup, so this isn't a problem. But the dynarec can call this function many times per frame.

Luma3DS implemements a svcCustomBackdoor call we can use that also runs a function in supervisor mode, but uses an implementation that avoids this problem.

Unfortunately, that means this fix depends on Luma3DS 8.0+. I don't think that's a bad requirement, because Luma3DS is the most popular CFW for the 3DS, and 8.0 is a few years old. We can version detect Luma3DS, and fall back to the partially working implementation if you're not running a compatible version.

Fixes #384 