### PR TITLE
Add an async CD access method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CFLAGS += -Wall -Iinclude -ffast-math
 ifeq ($(DEBUG), 1)
 CFLAGS += -O0 -ggdb
 else
-ifeq ($(platform), vita)
+ifeq ($(platform), $(filter $(platform), vita ctr))
 CFLAGS += -O3 -DNDEBUG
 else
 CFLAGS += -O2 -DNDEBUG

--- a/frontend/3ds/3ds_utils.h
+++ b/frontend/3ds/3ds_utils.h
@@ -24,6 +24,20 @@ void threadFree(int32_t thread);
 void threadExit(int32_t rc)  __attribute__((noreturn));
 
 int32_t svcGetSystemInfo(int64_t* out, uint32_t type, int32_t param);
+
+int32_t svcCreateSemaphore(uint32_t *sem, int32_t initial_count, uint32_t max_count);
+int32_t svcReleaseSemaphore(int32_t *count, uint32_t sem, int32_t release_count);
+int32_t svcWaitSynchronization(uint32_t handle, int64_t nanoseconds);
+
+typedef int32_t LightLock;
+
+void LightLock_Init(LightLock* lock);
+void LightLock_Lock(LightLock* lock);
+int LightLock_TryLock(LightLock* lock);
+void LightLock_Unlock(LightLock* lock);
+
+int32_t APT_CheckNew3DS(bool *out);
+
 int32_t svcBackdoor(int32_t (*callback)(void));
 
 #define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);wait_for_input();}while(0)

--- a/frontend/3ds/pthread.h
+++ b/frontend/3ds/pthread.h
@@ -9,15 +9,34 @@
 #include "3ds_utils.h"
 
 #define CTR_PTHREAD_STACK_SIZE 0x10000
+#define FALSE 0
 
 typedef int32_t pthread_t;
 typedef int pthread_attr_t;
 
+typedef LightLock pthread_mutex_t;
+typedef int pthread_mutexattr_t;
+
+typedef struct {
+  uint32_t semaphore;
+  LightLock lock;
+  uint32_t waiting;
+} pthread_cond_t;
+
+typedef int pthread_condattr_t;
+
 static inline int pthread_create(pthread_t *thread,
       const pthread_attr_t *attr, void *(*start_routine)(void*), void *arg)
 {
-   thread = threadCreate(start_routine, arg, CTR_PTHREAD_STACK_SIZE, 0x25, -2, FALSE);
-   return 1;
+   int procnum = -2; // use default cpu
+   bool isNew3DS;
+   APT_CheckNew3DS(&isNew3DS);
+
+   if (isNew3DS)
+     procnum = 2;
+
+   *thread = threadCreate(start_routine, arg, CTR_PTHREAD_STACK_SIZE, 0x25, procnum, FALSE);
+   return 0;
 }
 
 
@@ -39,6 +58,64 @@ static inline void pthread_exit(void *retval)
    (void)retval;
 
    threadExit(0);
+}
+
+static inline int pthread_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr) {
+  LightLock_Init(mutex);
+  return 0;
+}
+
+static inline int pthread_mutex_lock(pthread_mutex_t *mutex) {
+  LightLock_Lock(mutex);
+  return 0;
+}
+
+static inline int pthread_mutex_unlock(pthread_mutex_t *mutex) {
+  LightLock_Unlock(mutex);
+  return 0;
+}
+
+static inline int pthread_mutex_destroy(pthread_mutex_t *mutex) {
+  return 0;
+}
+
+static inline int pthread_cond_init(pthread_cond_t *cond, const pthread_condattr_t *attr) {
+  if (svcCreateSemaphore(&cond->semaphore, 0, 1))
+    goto error;
+
+  LightLock_Init(&cond->lock);
+  cond->waiting = 0;
+  return 0;
+
+ error:
+  svcCloseHandle(cond->semaphore);
+  return -1;
+}
+
+static inline int pthread_cond_signal(pthread_cond_t *cond) {
+  int32_t count;
+  LightLock_Lock(&cond->lock);
+  if (cond->waiting) {
+    cond->waiting--;
+    svcReleaseSemaphore(&count, cond->semaphore, 1);
+  }
+  LightLock_Unlock(&cond->lock);
+  return 0;
+}
+
+static inline int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *lock) {
+  LightLock_Lock(&cond->lock);
+  cond->waiting++;
+  LightLock_Unlock(lock);
+  LightLock_Unlock(&cond->lock);
+  svcWaitSynchronization(cond->semaphore, INT64_MAX);
+  LightLock_Lock(lock);
+  return 0;
+}
+
+static inline int pthread_cond_destroy(pthread_cond_t *cond) {
+  svcCloseHandle(cond->semaphore);
+  return 0;
 }
 
 

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1852,6 +1852,18 @@ static void update_variables(bool in_flight)
          Config.VSyncWA = 1;
    }
 
+#ifndef _WIN32
+   var.value = NULL;
+   var.key = "pcsx_rearmed_async_cd";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || var.value)
+   {
+      if (strcmp(var.value, "async") == 0)
+        Config.AsyncCD = 1;
+      else
+        Config.AsyncCD = 0;
+   }
+#endif
+
    var.value = NULL;
    var.key = "pcsx_rearmed_noxadecoding";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || var.value)

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -961,7 +961,19 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled",
    },
-
+#ifndef _WIN32
+   {
+      "pcsx_rearmed_async_cd",
+      "CD Access Method (Restart)",
+      "Select method used to read data from content disk images. 'Synchronous' mimics original hardware. 'Asynchronous' can reduce stuttering on devices with slow storage.",
+      {
+         { "sync", "Synchronous" },
+         { "async",  "Asynchronous" },
+         { NULL, NULL},
+      },
+      "sync",
+   },
+#endif
    /* ADVANCED OPTIONS */
    {
       "pcsx_rearmed_noxadecoding",

--- a/libpcsxcore/psxcommon.h
+++ b/libpcsxcore/psxcommon.h
@@ -120,6 +120,7 @@ typedef struct {
 	boolean Mdec;
 	boolean PsxAuto;
 	boolean Cdda;
+	boolean AsyncCD;
 	boolean HLE;
 	boolean SlowBoot;
 	boolean Debug;


### PR DESCRIPTION
This adds an option for asynchronous CD reads that acts like the one in Beetle PSX. When you turn it on:

- Data CD reads happen in a background thread
- The thread will try to prefetch the next few sectors when it's not fulfilling a request
- The thread will keep some data in a memory buffer, so it can quickly serve fetched data if it still exists

I've been running this on my 3DS for a week or so without issue. I haven't tested it on any other platform, but it should be possible to make it work on platforms that support pthreads. Right now I have it behind `!defined _WIN32`, since that's what controls other threading stuff in the core. But it might be better to have a specific flag for it.

I would like some more testing on this before it's merged, because I've only tried it on a limited number of games and on a single system. I'd also appreciate any more general feedback, because both my C and threading are rusty. But it has been a big improvement for me already. 