### PR TITLE
cdriso: fix a disk switching deadlock when closing a CD image

### DIFF
--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -1768,7 +1768,10 @@ static long CALLBACK ISOclose(void) {
 	memset(cdbuffer, 0, sizeof(cdbuffer));
 	CDR_getBuffer = ISOgetBuffer;
 
-  readThreadStop();
+	if (Config.AsyncCD) {
+		readThreadStop();
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
A few RetroPie users reported that disk switching freezes/crashes RetroArch, either doing the switch from a playlist (`.m3u`) or by appending a new disk image (no playlist).

I bisected the issue to the CD Async read  commit https://github.com/libretro/pcsx_rearmed/commit/8fda5dd0e28fe46621fb1ab57781c316143017da by @justinweiss. This can be worked around by choosing the `async` CD Read method in the core options, but `sync` is the default.

The change just adds a guard around `readThreadStop` - similar to how t's done to `readThreadStart` - and prevents the crash/deadlock.