### PR TITLE
Automatically disable lightrec when no bios is present

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1779,7 +1779,7 @@ static void update_variables(bool in_flight)
          Config.Cpu = CPU_INTERPRETER;
       else
 #endif
-      if (strcmp(var.value, "disabled") == 0)
+      if (strcmp(var.value, "disabled") == 0 || !found_bios)
          Config.Cpu = CPU_INTERPRETER;
       else if (strcmp(var.value, "enabled") == 0)
          Config.Cpu = CPU_DYNAREC;


### PR DESCRIPTION
Fixes https://github.com/libretro/pcsx_rearmed/issues/404