### PR TITLE
disable lightrec when no BIOS present; fixes #404 and corrects cf98d47

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1779,7 +1779,11 @@ static void update_variables(bool in_flight)
          Config.Cpu = CPU_INTERPRETER;
       else
 #endif
+#ifdef LIGHTREC
+      if (strcmp(var.value, "disabled") == 0 || !found_bios)
+#else
       if (strcmp(var.value, "disabled") == 0)
+#endif
          Config.Cpu = CPU_INTERPRETER;
       else if (strcmp(var.value, "enabled") == 0)
          Config.Cpu = CPU_DYNAREC;


### PR DESCRIPTION
wrapped the original overzealous fix in a LIGHTREC ifdef. This should make it only apply when the LIGHTREC is compiled in.