### PR TITLE
Minimize logs when loading a cheevos-compatible content

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1242,6 +1242,7 @@ strcasestr(const char *s, const char *find)
 
 static void set_retro_memmap(void)
 {
+#ifndef NDEBUG
    struct retro_memory_map retromap = { 0 };
    struct retro_memory_descriptor mmap = {
       0, psxM, 0, 0, 0, 0, 0x200000
@@ -1251,6 +1252,7 @@ static void set_retro_memmap(void)
    retromap.num_descriptors = 1;
 
    environ_cb(RETRO_ENVIRONMENT_SET_MEMORY_MAPS, &retromap);
+#endif
 }
 
 static void update_variables(bool in_flight);
@@ -2485,7 +2487,6 @@ static void print_internal_fps(void)
 
 void retro_run(void)
 {
-   int i;
    //SysReset must be run while core is running,Not in menu (Locks up Retroarch)
    if (rebootemu != 0)
    {


### PR DESCRIPTION
- Using retro_memory_descriptors[] for memmap creates a list of address for a game. At the moment, its quite long and can cover up the log window.
  Since there is only 1 pointer used, using the traditional retro_get_memory_map/data works enough for this purpose.

- Move the use of memory descriptors to debug build.