### PR TITLE
Fix interpreter-only build (DYNAREC=0)

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -59,18 +59,6 @@
 
 #define INTERNAL_FPS_SAMPLE_PERIOD 64
 
-#ifdef DRC_DISABLE
-int stop;
-u32 next_interupt;
-u32 event_cycles[PSXINT_COUNT];
-int cycle_multiplier;
-int new_dynarec_hacks;
-
-void new_dyna_before_save(void) {}
-void new_dyna_after_save(void) {}
-void new_dyna_freeze(void *f, int i) {}
-#endif
-
 //hack to prevent retroarch freezing when reseting in the menu but not while running with the hot key
 static int rebootemu = 0;
 


### PR DESCRIPTION
- For systems that can only run in interpreter mode for whatever reasons.

Fix: https://github.com/libretro/pcsx_rearmed/issues/408