### PR TITLE
change fast lighting default to disabled

### DIFF
--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -937,7 +937,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "enabled",  NULL },
          { NULL, NULL},
       },
-      "enabled",
+      "disabled",
    },
    {
       "pcsx_rearmed_gpu_unai_ilace_force",


### PR DESCRIPTION
- Setting this option enabled can cause graphics issues.

See ground polygons:
![Tales of Phantasia (Japan)-200803-172624](https://user-images.githubusercontent.com/54053706/89168307-42818900-d5af-11ea-97aa-bf54d1e740cb.png)
