### PR TITLE
Add an option to downscale hi-res views

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1999,6 +1999,17 @@ static void update_variables(bool in_flight)
          pl_rearmed_cbs.gpu_unai.blending = 1;
    }
 
+   var.key = "pcsx_rearmed_gpu_unai_scale_hires";
+   var.value = NULL;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (strcmp(var.value, "disabled") == 0)
+         pl_rearmed_cbs.gpu_unai.scale_hires = 0;
+      else if (strcmp(var.value, "enabled") == 0)
+         pl_rearmed_cbs.gpu_unai.scale_hires = 1;
+   }
+
    var.key = "pcsx_rearmed_show_gpu_unai_settings";
    var.value = NULL;
 
@@ -2014,17 +2025,18 @@ static void update_variables(bool in_flight)
       {
          unsigned i;
          struct retro_core_option_display option_display;
-         char gpu_unai_option[5][40] = {
+         char gpu_unai_option[6][40] = {
             "pcsx_rearmed_gpu_unai_blending",
             "pcsx_rearmed_gpu_unai_lighting",
             "pcsx_rearmed_gpu_unai_fast_lighting",
             "pcsx_rearmed_gpu_unai_ilace_force",
-            "pcsx_rearmed_gpu_unai_pixel_skip"
+            "pcsx_rearmed_gpu_unai_pixel_skip",
+            "pcsx_rearmed_gpu_unai_scale_hires"
          };
 
          option_display.visible = show_advanced_gpu_unai_settings;
 
-         for (i = 0; i < 5; i++)
+         for (i = 0; i < 6; i++)
          {
             option_display.key = gpu_unai_option[i];
             environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY, &option_display);

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -961,6 +961,17 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled",
    },
+   {
+      "pcsx_rearmed_gpu_unai_scale_hires",
+      "(GPU) Enable Hi-Res Downscaling",
+      "When enabled, will scale hi-res modes to 320x240, skipping unrendered pixels.",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL},
+      },
+      "disabled",
+   },
 #endif /* GPU UNAI Advanced Settings */
 
    {

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -140,6 +140,7 @@ void emu_set_default_config(void)
 	pl_rearmed_cbs.gpu_unai.abe_hack =
 	pl_rearmed_cbs.gpu_unai.no_light =
 	pl_rearmed_cbs.gpu_unai.no_blend = 0;
+	pl_rearmed_cbs.gpu_unai.scale_hires = 0;
 	memset(&pl_rearmed_cbs.gpu_peopsgl, 0, sizeof(pl_rearmed_cbs.gpu_peopsgl));
 	pl_rearmed_cbs.gpu_peopsgl.iVRamSize = 64;
 	pl_rearmed_cbs.gpu_peopsgl.iTexGarbageCollection = 1;

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -432,6 +432,7 @@ static const struct {
 	CE_INTVAL_P(gpu_unai.abe_hack),
 	CE_INTVAL_P(gpu_unai.no_light),
 	CE_INTVAL_P(gpu_unai.no_blend),
+	CE_INTVAL_P(gpu_unai.scale_hires),
 	CE_INTVAL_P(gpu_neon.allow_interlace),
 	CE_INTVAL_P(gpu_neon.enhancement_enable),
 	CE_INTVAL_P(gpu_neon.enhancement_no_main),

--- a/frontend/plugin_lib.h
+++ b/frontend/plugin_lib.h
@@ -91,6 +91,7 @@ struct rearmed_cbs {
 		int   abe_hack;
 		int   no_light, no_blend;
 		int   lineskip;
+		int   scale_hires;
 	} gpu_unai;
 	struct {
 		int   dwActFixes;

--- a/plugins/gpu_unai/gpu.h
+++ b/plugins/gpu_unai/gpu.h
@@ -38,6 +38,10 @@ struct gpu_unai_config_t {
 	                          //  Normally 0. Value '1' will skip rendering
 	                          //  odd lines.
 
+	uint8_t scale_hires:1;    // If 1, will scale hi-res output to
+	                          //  320x240 when gpulib reads the frame.
+	                          //  Implies pixel_skip and ilace_force
+	                          //  (when height > 240).
 	uint8_t lighting:1;
 	uint8_t fast_lighting:1;
 	uint8_t blending:1;

--- a/plugins/gpu_unai/gpu_unai.h
+++ b/plugins/gpu_unai/gpu_unai.h
@@ -138,6 +138,9 @@ struct gpu_unai_t {
 	GPUPacket PacketBuffer;
 	u16 *vram;
 
+#ifdef USE_GPULIB
+	u16 *downscale_vram;
+#endif
 	////////////////////////////////////////////////////////////////////////////
 	// Variables used only by older standalone version of gpu_unai (gpu.cpp)
 #ifndef USE_GPULIB
@@ -307,7 +310,7 @@ static inline bool ProgressiveInterlaceEnabled()
 //       running on higher-res device or a resampling downscaler is enabled.
 static inline bool PixelSkipEnabled()
 {
-	return gpu_unai.config.pixel_skip;
+	return gpu_unai.config.pixel_skip || gpu_unai.config.scale_hires;
 }
 
 static inline bool LineSkipEnabled()

--- a/plugins/gpulib/gpu.h
+++ b/plugins/gpulib/gpu.h
@@ -68,6 +68,8 @@ struct psx_gpu {
     uint32_t blanked:1;
     uint32_t enhancement_enable:1;
     uint32_t enhancement_active:1;
+    uint32_t downscale_enable:1;
+    uint32_t downscale_active:1;
     uint32_t *frame_count;
     uint32_t *hcnt; /* hsync count */
     struct {
@@ -90,6 +92,8 @@ struct psx_gpu {
   } frameskip;
   int useDithering:1; /* 0 - off , 1 - on */
   uint16_t *(*get_enhancement_bufer)
+    (int *x, int *y, int *w, int *h, int *vram_h);
+  uint16_t *(*get_downscale_buffer)
     (int *x, int *y, int *w, int *h, int *vram_h);
   void *(*mmap)(unsigned int size);
   void  (*munmap)(void *ptr, unsigned int size);

--- a/plugins/gpulib/vout_pl.c
+++ b/plugins/gpulib/vout_pl.c
@@ -43,6 +43,15 @@ static void check_mode_change(int force)
     h_out *= 2;
   }
 
+  gpu.state.downscale_active =
+    gpu.get_downscale_buffer != NULL && gpu.state.downscale_enable
+    && (w >= 512 || h >= 256);
+
+  if (gpu.state.downscale_active) {
+    w_out = w < 512 ? w : 320;
+    h_out = h < 256 ? h : h / 2;
+  }
+
   // width|rgb24 change?
   if (force || (gpu.status.reg ^ old_status) & ((7<<16)|(1<<21)) || h != old_h)
   {
@@ -68,6 +77,9 @@ void vout_update(void)
   check_mode_change(0);
   if (gpu.state.enhancement_active)
     vram = gpu.get_enhancement_bufer(&x, &y, &w, &h, &vram_h);
+
+  if (gpu.state.downscale_active)
+    vram = gpu.get_downscale_buffer(&x, &y, &w, &h, &vram_h);
 
   if (y + h > vram_h) {
     if (y + h - vram_h > h / 2) {


### PR DESCRIPTION
Some older devices that use gpu_unai don't have a high enough resolution to display all of the pixels in high-res mode. There's a setting in unai to skip rendering of these pixels, but it's not connected to the libretro frontend, and does not appear to be used in the gpulib implementation at all.

This commit adds a gpu_unai setting, Enable Hi-Res Downscaling, that will enable unai's pixel skipping and blit only the pixels actually rendered into a buffer no larger than 384x240. This buffer is then treated as the actual framebuffer by gpulib and the libretro frontend.