### PR TITLE
[3DS] Support latest libctru

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -208,9 +208,9 @@ else ifeq ($(platform), ctr)
 	AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
 	CFLAGS += -DARM11 -D_3DS -DNO_OS -DNO_DYLIB -DNO_SOCKET -DGPU_UNAI_USE_FLOATMATH -DGPU_UNAI_USE_FLOAT_DIV_MULTINV
 	CFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard -marm -mfpu=vfp -mtp=soft
-	CFLAGS += -Wall -mword-relocations
+	CFLAGS += -Wall -mword-relocations -fcommon
 	CFLAGS += -fomit-frame-pointer -ffast-math -funroll-loops
-	CFLAGS += -Ifrontend/3ds
+	CFLAGS += -Ifrontend/3ds -I$(CTRULIB)/include
 	CFLAGS += -Werror=implicit-function-declaration
 
 	OBJS += frontend/3ds/utils.o

--- a/frontend/3ds/3ds_utils.h
+++ b/frontend/3ds/3ds_utils.h
@@ -3,42 +3,11 @@
 
 #include <stdio.h>
 #include <stdbool.h>
+#include <3ds.h>
 
 #define MEMOP_PROT      6
 #define MEMOP_MAP       4
 #define MEMOP_UNMAP     5
-
-#define GET_VERSION_MAJOR(version)    ((version) >>24)
-
-void* linearMemAlign(size_t size, size_t alignment);
-void linearFree(void* mem);
-
-int32_t svcDuplicateHandle(uint32_t* out, uint32_t original);
-int32_t svcCloseHandle(uint32_t handle);
-int32_t svcControlMemory(void* addr_out, void* addr0, void* addr1, uint32_t size, uint32_t op, uint32_t perm);
-int32_t svcControlProcessMemory(uint32_t process, void* addr0, void* addr1, uint32_t size, uint32_t op, uint32_t perm);
-
-int32_t threadCreate(void *(*entrypoint)(void*), void* arg, size_t stack_size, int32_t prio, int32_t affinity, bool detached);
-int32_t threadJoin(int32_t thread, int64_t timeout_ns);
-void threadFree(int32_t thread);
-void threadExit(int32_t rc)  __attribute__((noreturn));
-
-int32_t svcGetSystemInfo(int64_t* out, uint32_t type, int32_t param);
-
-int32_t svcCreateSemaphore(uint32_t *sem, int32_t initial_count, uint32_t max_count);
-int32_t svcReleaseSemaphore(int32_t *count, uint32_t sem, int32_t release_count);
-int32_t svcWaitSynchronization(uint32_t handle, int64_t nanoseconds);
-
-typedef int32_t LightLock;
-
-void LightLock_Init(LightLock* lock);
-void LightLock_Lock(LightLock* lock);
-int LightLock_TryLock(LightLock* lock);
-void LightLock_Unlock(LightLock* lock);
-
-int32_t APT_CheckNew3DS(bool *out);
-
-int32_t svcBackdoor(int32_t (*callback)(void));
 
 #define DEBUG_HOLD() do{printf("%s@%s:%d.\n",__FUNCTION__, __FILE__, __LINE__);fflush(stdout);wait_for_input();}while(0)
 
@@ -46,7 +15,7 @@ void wait_for_input(void);
 
 extern __attribute__((weak)) int  __ctr_svchax;
 
-bool has_rosalina;
+static bool has_rosalina;
 
 static void check_rosalina() {
   int64_t version;


### PR DESCRIPTION
Similar to https://github.com/libretro/FFmpeg/pull/11 and https://github.com/libretro/ThePowderToy/pull/6, this needed a pthreads implementation that was compatible with both the old libretro-toolchains toolchain and the newest devkitARM toolchain. I used the same strategy here, although I didn't see it complain about the casts.

This also needed `-fcommon` to avoid duplicate definition errors under GCC 10.

Finally, I switched to using the 3ds.h header instead of the inline definitions, in order to avoid inconsistencies.

This successfully builds under both the version of devkitARM in libretro-toolchains and the newest devkitARM.