### PR TITLE
Correctly signal errors for out-of-bounds async CD reads

### DIFF
--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -1260,14 +1260,19 @@ static void *readThreadMain(void *param) {
       last_read_sector = requested_sector_end;
     }
 
+    index = ra_sector % SECTOR_BUFFER_SIZE;
+
     // check for end of CD
     if (ra_count && ra_sector >= max_sector) {
       ra_count = 0;
+      pthread_mutex_lock(&sectorbuffer_lock);
+      sectorbuffer[index].ret = -1;
+      sectorbuffer[index].sector = ra_sector;
+      pthread_cond_signal(&sectorbuffer_cond);
+      pthread_mutex_unlock(&sectorbuffer_lock);
     }
 
     if (ra_count) {
-
-      index = ra_sector % SECTOR_BUFFER_SIZE;
       pthread_mutex_lock(&sectorbuffer_lock);
       if (sectorbuffer[index].sector != ra_sector) {
         pthread_mutex_unlock(&sectorbuffer_lock);


### PR DESCRIPTION
Previously, when an access went out of bounds, we would stop reading ahead, but not add the error flag to the correct place in the sector buffer. This could hang the main thread as it waited for a read result that would never come.