### PR TITLE
Revert "fixes link time errors on the RPi platform (tested with 3 and 4)"

### DIFF
--- a/libpcsxcore/psxcounters.c
+++ b/libpcsxcore/psxcounters.c
@@ -70,6 +70,8 @@ static const s32 VerboseLevel     = VERBOSE_LEVEL;
 
 /******************************************************************************/
 
+Rcnt rcnts[ CounterQuantity ];
+
 u32 hSyncCount = 0;
 u32 frame_counter = 0;
 static u32 hsync_steps = 0;
@@ -494,7 +496,7 @@ s32 psxRcntFreeze( void *f, s32 Mode )
     u32 count;
     s32 i;
 
-    gzfreeze( &rcnts, sizeof(*rcnts) * CounterQuantity );
+    gzfreeze( &rcnts, sizeof(rcnts) );
     gzfreeze( &hSyncCount, sizeof(hSyncCount) );
     gzfreeze( &spuSyncCount, sizeof(spuSyncCount) );
     gzfreeze( &psxNextCounter, sizeof(psxNextCounter) );

--- a/libpcsxcore/psxcounters.h
+++ b/libpcsxcore/psxcounters.h
@@ -39,7 +39,6 @@ typedef struct Rcnt
     u32 rate, irq, counterState, irqState;
     u32 cycle, cycleStart;
 } Rcnt;
-
 extern Rcnt rcnts[];
 
 void psxRcntInit();

--- a/libpcsxcore/r3000a.c
+++ b/libpcsxcore/r3000a.c
@@ -27,6 +27,7 @@
 #include "gte.h"
 
 R3000Acpu *psxCpu = NULL;
+psxRegisters psxRegs;
 
 int psxInit() {
 	SysPrintf(_("Running PCSX Version %s (%s).\n"), PCSX_VERSION, __DATE__);


### PR DESCRIPTION
Reverts libretro/pcsx_rearmed#458