### PR TITLE
[3DS] Set default CPU rate to the usual 57

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -2828,7 +2828,7 @@ void retro_init(void)
     * we have to do this because cache misses and some IO penalties
     * are not emulated. Warning: changing this may break compatibility. */
    cycle_multiplier = 175;
-#ifdef HAVE_PRE_ARMV7
+#if defined(HAVE_PRE_ARMV7) && !defined(_3DS)
    cycle_multiplier = 200;
 #endif
    pl_rearmed_cbs.gpu_peops.iUseDither = 1;

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -633,7 +633,7 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "pcsx_rearmed_psxclock",
       "PSX CPU Clock",
-#ifdef HAVE_PRE_ARMV7
+#if defined(HAVE_PRE_ARMV7) && !defined(_3DS)
       "Overclock or underclock the PSX clock. Default is 50",
 #else
       "Overclock or underclock the PSX clock. Default is 57",
@@ -712,7 +712,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "100", NULL },
          { NULL, NULL },
       },
-#ifdef HAVE_PRE_ARMV7
+#if defined(HAVE_PRE_ARMV7) && !defined(_3DS)
       "50",
 #else
       "57",


### PR DESCRIPTION
3DS handles it fine, and 50 makes Metal Gear Solid feel very sluggish.