### PR TITLE
iOS: Fix interpreter overrides

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -89,7 +89,7 @@ else ifeq ($(platform),$(filter $(platform),ios-arm64))
 
 else ifneq (,$(findstring ios,$(platform)))
 	ARCH := arm
-	DYNAREC ?= ari64
+#	DYNAREC ?= ari64
 	HAVE_NEON = 1
 	BUILTIN_GPU = neon
 	TARGET := $(TARGET_NAME)_libretro_ios.dylib


### PR DESCRIPTION
By default, iOS are built with either DYNAREC=ari64 or DYNAREC=lightrec, with lightrec used as an override flag to build the interpreter instead, which is DYNAREC=0.

This PR removes DYNAREC?=ari64 which seems to block the overrides from working.

Hopefully...: