### PR TITLE
Allow threaded rendering for peops and enable on unix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,10 +184,6 @@ endif
 ifeq "$(BUILTIN_GPU)" "unai"
 CFLAGS += -DGPU_UNAI
 CFLAGS += -DUSE_GPULIB=1
-ifeq "$(THREAD_RENDERING)" "1"
-CFLAGS += -DTHREAD_RENDERING
-OBJS += plugins/gpulib/gpulib_thread_if.o
-endif
 #CFLAGS += -DINLINE="static __inline__"
 #CFLAGS += -Dasm="__asm__ __volatile__"
 OBJS += plugins/gpu_unai/gpulib_if.o
@@ -196,6 +192,10 @@ OBJS += plugins/gpu_unai/gpu_arm.o
 endif
 plugins/gpu_unai/gpulib_if.o: CFLAGS += -DREARMED -O3 
 CC_LINK = $(CXX)
+endif
+ifeq "$(THREAD_RENDERING)" "1"
+CFLAGS += -DTHREAD_RENDERING
+OBJS += plugins/gpulib/gpulib_thread_if.o
 endif
 
 # cdrcimg

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -48,6 +48,7 @@ EXTRA_LDFLAGS =
 ifeq ($(platform), unix)
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
+	THREAD_RENDERING = 1
 ifneq ($(findstring SunOS,$(shell uname -s)),)
 	CC = gcc
 endif

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -972,6 +972,7 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled",
    },
+#endif /* GPU UNAI Advanced Settings */
 #ifdef THREAD_RENDERING
    {
       "pcsx_rearmed_gpu_thread_rendering",
@@ -986,7 +987,6 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled",
    },
 #endif
-#endif /* GPU UNAI Advanced Settings */
 
    {
       "pcsx_rearmed_show_bios_bootlogo",

--- a/plugins/dfxvideo/gpulib_if.c
+++ b/plugins/dfxvideo/gpulib_if.c
@@ -17,6 +17,22 @@
 #include <string.h>
 #include "../gpulib/gpu.h"
 
+#ifdef THREAD_RENDERING
+#include "../gpulib/gpulib_thread_if.h"
+#define do_cmd_list real_do_cmd_list
+#define renderer_init real_renderer_init
+#define renderer_finish real_renderer_finish
+#define renderer_sync_ecmds real_renderer_sync_ecmds
+#define renderer_update_caches real_renderer_update_caches
+#define renderer_flush_queues real_renderer_flush_queues
+#define renderer_set_interlace real_renderer_set_interlace
+#define renderer_set_config real_renderer_set_config
+#define renderer_notify_res_change real_renderer_notify_res_change
+#define renderer_notify_update_lace real_renderer_notify_update_lace
+#define renderer_sync real_renderer_sync
+#define ex_regs scratch_ex_regs
+#endif
+
 #define u32 uint32_t
 
 #define INFO_TW        0


### PR DESCRIPTION
This allows peops to use threaded rendering, and shows the setting on unix builds (this was the only other platform I have on hand to test). Enabling the setting on other pthread-compatible platforms using either unai or peops should be as simple as defining `THREAD_RENDERING` in the Makefile. 

A change similar to this one should work with gpu_neon, but I don't have any neon devices on hand to check with. Should be straightforward if someone wants to try.