### PR TITLE
Fix build with -fno-common (default in gcc10)

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -186,7 +186,7 @@ else ifeq ($(platform), vita)
 	CFLAGS += -mcpu=cortex-a8 -mtune=cortex-a8 -mfpu=neon -marm
 	CFLAGS += -fsingle-precision-constant -mword-relocations -fno-unwind-tables
 	CFLAGS += -fno-asynchronous-unwind-tables -ftree-vectorize -funroll-loops
-	CFLAGS += -fno-optimize-sibling-calls -fcommon
+	CFLAGS += -fno-optimize-sibling-calls
 	CFLAGS += -I$(VITASDK)/include -Ifrontend/vita
 	CFLAGS += -DNO_SOCKET -DNO_OS -DNO_DYLIB
 	ASFLAGS += -mcpu=cortex-a8 -mtune=cortex-a8 -mfpu=neon
@@ -209,7 +209,7 @@ else ifeq ($(platform), ctr)
 	AR = $(DEVKITARM)/bin/arm-none-eabi-ar$(EXE_EXT)
 	CFLAGS += -DARM11 -D_3DS -DNO_OS -DNO_DYLIB -DNO_SOCKET -DTHREAD_ENABLED -DGPU_UNAI_USE_FLOATMATH -DGPU_UNAI_USE_FLOAT_DIV_MULTINV
 	CFLAGS += -march=armv6k -mtune=mpcore -mfloat-abi=hard -marm -mfpu=vfp -mtp=soft
-	CFLAGS += -Wall -mword-relocations -fcommon
+	CFLAGS += -Wall -mword-relocations
 	CFLAGS += -fomit-frame-pointer -ffast-math -funroll-loops
 	CFLAGS += -Ifrontend/3ds -I$(CTRULIB)/include
 	CFLAGS += -Werror=implicit-function-declaration

--- a/libpcsxcore/psxcounters.c
+++ b/libpcsxcore/psxcounters.c
@@ -70,7 +70,9 @@ static const s32 VerboseLevel     = VERBOSE_LEVEL;
 
 /******************************************************************************/
 
+#ifndef NEW_DYNAREC
 Rcnt rcnts[ CounterQuantity ];
+#endif
 
 u32 hSyncCount = 0;
 u32 frame_counter = 0;
@@ -496,7 +498,7 @@ s32 psxRcntFreeze( void *f, s32 Mode )
     u32 count;
     s32 i;
 
-    gzfreeze( &rcnts, sizeof(rcnts) );
+    gzfreeze( &rcnts, sizeof(Rcnt) * CounterQuantity );
     gzfreeze( &hSyncCount, sizeof(hSyncCount) );
     gzfreeze( &spuSyncCount, sizeof(spuSyncCount) );
     gzfreeze( &psxNextCounter, sizeof(psxNextCounter) );

--- a/libpcsxcore/r3000a.c
+++ b/libpcsxcore/r3000a.c
@@ -27,7 +27,9 @@
 #include "gte.h"
 
 R3000Acpu *psxCpu = NULL;
+#ifndef NEW_DYNAREC
 psxRegisters psxRegs;
+#endif
 
 int psxInit() {
 	SysPrintf(_("Running PCSX Version %s (%s).\n"), PCSX_VERSION, __DATE__);


### PR DESCRIPTION
Affects builds that uses ari64 (DYNAREC=ari64). Two variables, rcnt and psxRegs causes these platform to fail on gcc10.

This PR blocks the stated variables with #ifdef when building with ari64, and use the definition for the vars from **libpcsxcore/new_dynarec/arm/linkage_arm.S** instead to avoid the multiple definition errors when linking.

I have not personally tested the core to run, only compilation and linking with RA.

for review @twinaphex @@justinweiss @dmorilha