### PR TITLE
Set multitap options to "disabled" by default

### DIFF
--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -166,7 +166,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "enabled",  NULL },
          { NULL, NULL },
       },
-      "auto",
+      "disabled",
    },
    {
       "pcsx_rearmed_multitap2",
@@ -178,7 +178,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "enabled",  NULL },
          { NULL, NULL },
       },
-      "auto",
+      "disabled",
    },
    {
       "pcsx_rearmed_negcon_deadzone",


### PR DESCRIPTION
Due to moving input selector to frontend instead from the core options,
ports 3-8 can be always set to standard causing multitap to be auto-activated.
With multitaps enabled, some games would misbehave or inputs not working
at all for those that are not multiplayer capable.

Setting core option multitap1 and multitap2 to disable for now.