### PR TITLE
Change HLE BIOS message. Please review first!

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -2725,11 +2725,19 @@ static void loadPSXBios(void)
       }
    }
 
-   if (useHLE || !found_bios)
+   if (!found_bios)
    {
-      const char *msg_str = "No PlayStation BIOS file found - add for better compatibility";
-
-      SysPrintf("no BIOS files found.\n");
+      const char *msg_str;
+      if (useHLE)
+      {
+         msg_str = "BIOS set to \'hle\' in core options - real BIOS will be ignored";
+         SysPrintf("Using HLE BIOS.\n");
+      }
+      else
+      {
+         msg_str = "No PlayStation BIOS file found - add for better compatibility";
+         SysPrintf("No BIOS files found.\n");
+      }
 
       if (msg_interface_version >= 1)
       {


### PR DESCRIPTION
At the moment, if you have "hle" BIOS selected in core options it will show a "no PlayStation BIOS found" message, even if you have a BIOS file in your system folder. It seems to confuse some people, so I think it would be nice to have a different message displaying in this case.

It's a really simple PR but I'm not a dev (I just have some bash scripting knowledge... 😅 ), so I'm "afraid" to break something, the logic itself works fine, but I'm not sure about a few things:

1. The message itself, does it make sense to you? Kinda hard to make something clear while keeping it short. But it hints the user at checking the core options and it clearly states that if you have a real BIOS it won't be used.
2. I escaped the `'` in the message itself to be safe but I'm not sure if needed or completely useless (it doesn't seem to change anything on Windows at least).
3. Did I do the "msg_str" thing properly? That's the part where I'm really unsure, in the code sometimes I see `const char *xxx = NULL;` and sometimes just `const char *xxx;` like I did... Seems to have worked fine in both cases in my tests but idk if one way is better than the other for this :/

With "hle" BIOS in core options (no matter if you have a "scph" file or not):

![image](https://user-images.githubusercontent.com/33353403/107934743-b9490700-6f80-11eb-87af-d9ebf55dc56d.png)

And with no "scph" file in system folder (no change):

![image](https://user-images.githubusercontent.com/33353403/107934930-f31a0d80-6f80-11eb-9e7c-c72d92c671de.png)
