### PR TITLE
Selectively replace fopen() with fopen_utf8()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,7 @@ CFLAGS += `pkg-config --cflags glib-2.0 libosso dbus-1 hildon-fm-2`
 LDFLAGS += `pkg-config --libs glib-2.0 libosso dbus-1 hildon-fm-2`
 endif
 ifeq "$(PLATFORM)" "libretro"
+OBJS += libretro-common/compat/fopen_utf8.o
 OBJS += frontend/libretro.o
 CFLAGS += -Ilibretro-common/include
 CFLAGS += -DFRONTEND_SUPPORTS_RGB565

--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,8 @@ LDFLAGS += `pkg-config --libs glib-2.0 libosso dbus-1 hildon-fm-2`
 endif
 ifeq "$(PLATFORM)" "libretro"
 OBJS += libretro-common/compat/fopen_utf8.o
+OBJS += libretro-common/encodings/compat_strl.o
+OBJS += libretro-common/encodings/encoding_utf.o
 OBJS += frontend/libretro.o
 CFLAGS += -Ilibretro-common/include
 CFLAGS += -DFRONTEND_SUPPORTS_RGB565

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -39,6 +39,7 @@
 #include "revision.h"
 
 #include <libretro.h>
+#include <compat/fopen_utf8.h>
 #include "libretro_core_options.h"
 
 #ifdef _3DS
@@ -1112,7 +1113,7 @@ static bool read_m3u(const char *file)
 {
    char line[1024];
    char name[PATH_MAX];
-   FILE *f = fopen(file, "r");
+   FILE *f = fopen_utf8(file, "r");
    if (!f)
       return false;
 
@@ -2572,7 +2573,7 @@ static bool try_use_bios(const char *path)
    long size;
    const char *name;
 
-   f = fopen(path, "rb");
+   f = fopen_utf8(path, "rb");
    if (f == NULL)
       return false;
 

--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -19,6 +19,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.           *
  ***************************************************************************/
 
+#include <compat/fopen_utf8.h>
+
 #include "psxcommon.h"
 #include "plugins.h"
 #include "cdrom.h"
@@ -334,16 +336,16 @@ static int parsetoc(const char *isofile) {
 		return -1;
 	}
 
-	if ((fi = fopen(tocname, "r")) == NULL) {
+	if ((fi = fopen_utf8(tocname, "r")) == NULL) {
 		// try changing extension to .cue (to satisfy some stupid tutorials)
 		strcpy(tocname + strlen(tocname) - 4, ".cue");
-		if ((fi = fopen(tocname, "r")) == NULL) {
+		if ((fi = fopen_utf8(tocname, "r")) == NULL) {
 			// if filename is image.toc.bin, try removing .bin (for Brasero)
 			strcpy(tocname, isofile);
 			t = strlen(tocname);
 			if (t >= 8 && strcmp(tocname + t - 8, ".toc.bin") == 0) {
 				tocname[t - 4] = '\0';
-				if ((fi = fopen(tocname, "r")) == NULL) {
+				if ((fi = fopen_utf8(tocname, "r")) == NULL) {
 					return -1;
 				}
 			}
@@ -486,7 +488,7 @@ static int parsecue(const char *isofile) {
 		return -1;
 	}
 
-	if ((fi = fopen(cuename, "r")) == NULL) {
+	if ((fi = fopen_utf8(cuename, "r")) == NULL) {
 		return -1;
 	}
 
@@ -590,7 +592,7 @@ static int parsecue(const char *isofile) {
 			else
 				tmp = tmpb;
 			strncpy(incue_fname, tmp, incue_max_len);
-			ti[numtracks + 1].handle = fopen(filepath, "rb");
+			ti[numtracks + 1].handle = fopen_utf8(filepath, "rb");
 
 			// update global offset if this is not first file in this .cue
 			if (numtracks + 1 > 1) {
@@ -611,7 +613,7 @@ static int parsecue(const char *isofile) {
 				strncasecmp(isofile + strlen(isofile) - 4, ".cd", 3) == 0)) {
 				// user selected .cue/.cdX as image file, use it's data track instead
 				fclose(cdHandle);
-				cdHandle = fopen(filepath, "rb");
+				cdHandle = fopen_utf8(filepath, "rb");
 			}
 		}
 	}
@@ -645,7 +647,7 @@ static int parseccd(const char *isofile) {
 		return -1;
 	}
 
-	if ((fi = fopen(ccdname, "r")) == NULL) {
+	if ((fi = fopen_utf8(ccdname, "r")) == NULL) {
 		return -1;
 	}
 
@@ -704,7 +706,7 @@ static int parsemds(const char *isofile) {
 		return -1;
 	}
 
-	if ((fi = fopen(mdsname, "rb")) == NULL) {
+	if ((fi = fopen_utf8(mdsname, "rb")) == NULL) {
 		return -1;
 	}
 
@@ -1144,7 +1146,7 @@ static int opensubfile(const char *isoname) {
 		return -1;
 	}
 
-	subHandle = fopen(subname, "rb");
+	subHandle = fopen_utf8(subname, "rb");
 	if (subHandle == NULL) {
 		return -1;
 	}
@@ -1623,7 +1625,7 @@ static long CALLBACK ISOopen(void) {
 		return 0; // it's already open
 	}
 
-	cdHandle = fopen(GetIsoFile(), "rb");
+	cdHandle = fopen_utf8(GetIsoFile(), "rb");
 	if (cdHandle == NULL) {
 		SysPrintf(_("Could't open '%s' for reading: %s\n"),
 			GetIsoFile(), strerror(errno));
@@ -1695,7 +1697,7 @@ static long CALLBACK ISOopen(void) {
 			p = alt_bin_filename + strlen(alt_bin_filename) - 4;
 			for (i = 0; i < sizeof(exts) / sizeof(exts[0]); i++) {
 				strcpy(p, exts[i]);
-				tmpf = fopen(alt_bin_filename, "rb");
+				tmpf = fopen_utf8(alt_bin_filename, "rb");
 				if (tmpf != NULL)
 					break;
 			}
@@ -1731,7 +1733,7 @@ static long CALLBACK ISOopen(void) {
 
 	// make sure we have another handle open for cdda
 	if (numtracks > 1 && ti[1].handle == NULL) {
-		ti[1].handle = fopen(bin_filename, "rb");
+		ti[1].handle = fopen_utf8(bin_filename, "rb");
 	}
 	cdda_cur_sector = 0;
 	cdda_file_offset = 0;

--- a/libpcsxcore/psxmem.c
+++ b/libpcsxcore/psxmem.c
@@ -23,6 +23,8 @@
 
 // TODO: Implement caches & cycle penalty.
 
+#include <compat/fopen_utf8.h>
+
 #include "psxmem.h"
 #include "psxmem_map.h"
 #include "r3000a.h"
@@ -217,7 +219,7 @@ void psxMemReset() {
 
 	if (strcmp(Config.Bios, "HLE") != 0) {
 		sprintf(bios, "%s/%s", Config.BiosDir, Config.Bios);
-		f = fopen(bios, "rb");
+		f = fopen_utf8(bios, "rb");
 
 		if (f == NULL) {
 			SysMessage(_("Could not open BIOS:\"%s\". Enabling HLE Bios!\n"), bios);

--- a/libpcsxcore/sio.c
+++ b/libpcsxcore/sio.c
@@ -17,6 +17,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02111-1307 USA.           *
  ***************************************************************************/
 
+#include <compat/fopen_utf8.h>
+
 /*
 * SIO functions.
 */
@@ -436,11 +438,11 @@ void LoadMcd(int mcd, char *str) {
 	if (*str == 0)
 		return;
 
-	f = fopen(str, "rb");
+	f = fopen_utf8(str, "rb");
 	if (f == NULL) {
 		SysPrintf(_("The memory card %s doesn't exist - creating it\n"), str);
 		CreateMcd(str);
-		f = fopen(str, "rb");
+		f = fopen_utf8(str, "rb");
 		if (f != NULL) {
 			struct stat buf;
 
@@ -481,7 +483,7 @@ void SaveMcd(char *mcd, char *data, uint32_t adr, int size) {
 	if (mcd == NULL || *mcd == 0 || strcmp(mcd, "none") == 0)
 		return;
 
-	f = fopen(mcd, "r+b");
+	f = fopen_utf8(mcd, "r+b");
 	if (f != NULL) {
 		struct stat buf;
 
@@ -518,7 +520,7 @@ void CreateMcd(char *mcd) {
 	int s = MCD_SIZE;
 	int i = 0, j;
 
-	f = fopen(mcd, "wb");
+	f = fopen_utf8(mcd, "wb");
 	if (f == NULL)
 		return;
 

--- a/libretro-common/encodings/compat_strl.c
+++ b/libretro-common/encodings/compat_strl.c
@@ -1,0 +1,69 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (compat_strl.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdlib.h>
+#include <ctype.h>
+
+#include <compat/strl.h>
+
+/* Implementation of strlcpy()/strlcat() based on OpenBSD. */
+
+#ifndef __MACH__
+
+size_t strlcpy(char *dest, const char *source, size_t size)
+{
+   size_t src_size = 0;
+   size_t        n = size;
+
+   if (n)
+      while (--n && (*dest++ = *source++)) src_size++;
+
+   if (!n)
+   {
+      if (size) *dest = '\0';
+      while (*source++) src_size++;
+   }
+
+   return src_size;
+}
+
+size_t strlcat(char *dest, const char *source, size_t size)
+{
+   size_t len = strlen(dest);
+
+   dest += len;
+
+   if (len > size)
+      size = 0;
+   else
+      size -= len;
+
+   return len + strlcpy(dest, source, size);
+}
+#endif
+
+char *strldup(const char *s, size_t n)
+{
+   char *dst = (char*)malloc(sizeof(char) * (n + 1));
+   strlcpy(dst, s, n);
+   return dst;
+}

--- a/libretro-common/encodings/encoding_utf.c
+++ b/libretro-common/encodings/encoding_utf.c
@@ -1,0 +1,512 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (encoding_utf.c).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <boolean.h>
+#include <compat/strl.h>
+#include <retro_inline.h>
+
+#include <encodings/utf.h>
+
+#if defined(_WIN32) && !defined(_XBOX)
+#include <windows.h>
+#elif defined(_XBOX)
+#include <xtl.h>
+#endif
+
+#define UTF8_WALKBYTE(string) (*((*(string))++))
+
+static unsigned leading_ones(uint8_t c)
+{
+   unsigned ones = 0;
+   while (c & 0x80)
+   {
+      ones++;
+      c <<= 1;
+   }
+
+   return ones;
+}
+
+/* Simple implementation. Assumes the sequence is
+ * properly synchronized and terminated. */
+
+size_t utf8_conv_utf32(uint32_t *out, size_t out_chars,
+      const char *in, size_t in_size)
+{
+   unsigned i;
+   size_t ret = 0;
+   while (in_size && out_chars)
+   {
+      unsigned extra, shift;
+      uint32_t c;
+      uint8_t first = *in++;
+      unsigned ones = leading_ones(first);
+
+      if (ones > 6 || ones == 1) /* Invalid or desync. */
+         break;
+
+      extra = ones ? ones - 1 : ones;
+      if (1 + extra > in_size) /* Overflow. */
+         break;
+
+      shift = (extra - 1) * 6;
+      c     = (first & ((1 << (7 - ones)) - 1)) << (6 * extra);
+
+      for (i = 0; i < extra; i++, in++, shift -= 6)
+         c |= (*in & 0x3f) << shift;
+
+      *out++ = c;
+      in_size -= 1 + extra;
+      out_chars--;
+      ret++;
+   }
+
+   return ret;
+}
+
+bool utf16_conv_utf8(uint8_t *out, size_t *out_chars,
+     const uint16_t *in, size_t in_size)
+{
+   size_t out_pos            = 0;
+   size_t in_pos             = 0;
+   static const 
+      uint8_t utf8_limits[5] = { 0xC0, 0xE0, 0xF0, 0xF8, 0xFC };
+
+   for (;;)
+   {
+      unsigned num_adds;
+      uint32_t value;
+
+      if (in_pos == in_size)
+      {
+         *out_chars = out_pos;
+         return true;
+      }
+      value = in[in_pos++];
+      if (value < 0x80)
+      {
+         if (out)
+            out[out_pos] = (char)value;
+         out_pos++;
+         continue;
+      }
+
+      if (value >= 0xD800 && value < 0xE000)
+      {
+         uint32_t c2;
+
+         if (value >= 0xDC00 || in_pos == in_size)
+            break;
+         c2 = in[in_pos++];
+         if (c2 < 0xDC00 || c2 >= 0xE000)
+            break;
+         value = (((value - 0xD800) << 10) | (c2 - 0xDC00)) + 0x10000;
+      }
+
+      for (num_adds = 1; num_adds < 5; num_adds++)
+         if (value < (((uint32_t)1) << (num_adds * 5 + 6)))
+            break;
+      if (out)
+         out[out_pos] = (char)(utf8_limits[num_adds - 1]
+               + (value >> (6 * num_adds)));
+      out_pos++;
+      do
+      {
+         num_adds--;
+         if (out)
+            out[out_pos] = (char)(0x80
+                  + ((value >> (6 * num_adds)) & 0x3F));
+         out_pos++;
+      }while (num_adds != 0);
+   }
+
+   *out_chars = out_pos;
+   return false;
+}
+
+/* Acts mostly like strlcpy.
+ *
+ * Copies the given number of UTF-8 characters,
+ * but at most d_len bytes.
+ *
+ * Always NULL terminates.
+ * Does not copy half a character.
+ *
+ * Returns number of bytes. 's' is assumed valid UTF-8.
+ * Use only if 'chars' is considerably less than 'd_len'. */
+size_t utf8cpy(char *d, size_t d_len, const char *s, size_t chars)
+{
+   const uint8_t *sb     = (const uint8_t*)s;
+   const uint8_t *sb_org = sb;
+
+   if (!s)
+      return 0;
+
+   while (*sb && chars-- > 0)
+   {
+      sb++;
+      while ((*sb & 0xC0) == 0x80)
+         sb++;
+   }
+
+   if ((size_t)(sb - sb_org) > d_len-1 /* NUL */)
+   {
+      sb = sb_org + d_len-1;
+      while ((*sb & 0xC0) == 0x80)
+         sb--;
+   }
+
+   memcpy(d, sb_org, sb-sb_org);
+   d[sb-sb_org] = '\0';
+
+   return sb-sb_org;
+}
+
+const char *utf8skip(const char *str, size_t chars)
+{
+   const uint8_t *strb = (const uint8_t*)str;
+
+   if (!chars)
+      return str;
+
+   do
+   {
+      strb++;
+      while ((*strb & 0xC0)==0x80)
+         strb++;
+      chars--;
+   }while (chars);
+
+   return (const char*)strb;
+}
+
+size_t utf8len(const char *string)
+{
+   size_t ret = 0;
+
+   if (!string)
+      return 0;
+
+   while (*string)
+   {
+      if ((*string & 0xC0) != 0x80)
+         ret++;
+      string++;
+   }
+   return ret;
+}
+
+/* Does not validate the input, returns garbage if it's not UTF-8. */
+uint32_t utf8_walk(const char **string)
+{
+   uint8_t first = UTF8_WALKBYTE(string);
+   uint32_t ret  = 0;
+
+   if (first < 128)
+      return first;
+
+   ret    = (ret << 6) | (UTF8_WALKBYTE(string) & 0x3F);
+   if (first >= 0xE0)
+   {
+      ret = (ret << 6) | (UTF8_WALKBYTE(string) & 0x3F);
+      if (first >= 0xF0)
+      {
+         ret = (ret << 6) | (UTF8_WALKBYTE(string) & 0x3F);
+         return ret | (first & 7) << 18;
+      }
+      return ret | (first & 15) << 12;
+   }
+
+   return ret | (first & 31) << 6;
+}
+
+static bool utf16_to_char(uint8_t **utf_data,
+      size_t *dest_len, const uint16_t *in)
+{
+   unsigned len    = 0;
+
+   while (in[len] != '\0')
+      len++;
+
+   utf16_conv_utf8(NULL, dest_len, in, len);
+   *dest_len  += 1;
+   *utf_data   = (uint8_t*)malloc(*dest_len);
+   if (*utf_data == 0)
+      return false;
+
+   return utf16_conv_utf8(*utf_data, dest_len, in, len);
+}
+
+bool utf16_to_char_string(const uint16_t *in, char *s, size_t len)
+{
+   size_t     dest_len  = 0;
+   uint8_t *utf16_data  = NULL;
+   bool            ret  = utf16_to_char(&utf16_data, &dest_len, in);
+
+   if (ret)
+   {
+      utf16_data[dest_len] = 0;
+      strlcpy(s, (const char*)utf16_data, len);
+   }
+
+   free(utf16_data);
+   utf16_data = NULL;
+
+   return ret;
+}
+
+#if defined(_WIN32) && !defined(_XBOX) && !defined(UNICODE)
+/* Returned pointer MUST be freed by the caller if non-NULL. */
+static char *mb_to_mb_string_alloc(const char *str,
+      enum CodePage cp_in, enum CodePage cp_out)
+{
+   wchar_t *path_buf_wide = NULL;
+   int path_buf_wide_len  = MultiByteToWideChar(cp_in, 0, str, -1, NULL, 0);
+
+   /* Windows 95 will return 0 from these functions with 
+    * a UTF8 codepage set without MSLU.
+    *
+    * From an unknown MSDN version (others omit this info):
+    *   - CP_UTF8 Windows 98/Me, Windows NT 4.0 and later: 
+    *   Translate using UTF-8. When this is set, dwFlags must be zero.
+    *   - Windows 95: Under the Microsoft Layer for Unicode, 
+    *   MultiByteToWideChar also supports CP_UTF7 and CP_UTF8.
+    */
+
+   if (!path_buf_wide_len)
+      return strdup(str);
+
+   path_buf_wide = (wchar_t*)
+      calloc(path_buf_wide_len + sizeof(wchar_t), sizeof(wchar_t));
+
+   if (path_buf_wide)
+   {
+      MultiByteToWideChar(cp_in, 0,
+            str, -1, path_buf_wide, path_buf_wide_len);
+
+      if (*path_buf_wide)
+      {
+         int path_buf_len = WideCharToMultiByte(cp_out, 0,
+               path_buf_wide, -1, NULL, 0, NULL, NULL);
+
+         if (path_buf_len)
+         {
+            char *path_buf = (char*)
+               calloc(path_buf_len + sizeof(char), sizeof(char));
+
+            if (path_buf)
+            {
+               WideCharToMultiByte(cp_out, 0,
+                     path_buf_wide, -1, path_buf,
+                     path_buf_len, NULL, NULL);
+
+               free(path_buf_wide);
+
+               if (*path_buf)
+                  return path_buf;
+
+               free(path_buf);
+               return NULL;
+            }
+         }
+         else
+         {
+            free(path_buf_wide);
+            return strdup(str);
+         }
+      }
+
+      free(path_buf_wide);
+   }
+
+   return NULL;
+}
+#endif
+
+/* Returned pointer MUST be freed by the caller if non-NULL. */
+char* utf8_to_local_string_alloc(const char *str)
+{
+   if (str && *str)
+   {
+#if defined(_WIN32) && !defined(_XBOX) && !defined(UNICODE)
+      return mb_to_mb_string_alloc(str, CODEPAGE_UTF8, CODEPAGE_LOCAL);
+#else
+      /* assume string needs no modification if not on Windows */
+      return strdup(str);
+#endif
+   }
+   return NULL;
+}
+
+/* Returned pointer MUST be freed by the caller if non-NULL. */
+char* local_to_utf8_string_alloc(const char *str)
+{
+   if (str && *str)
+   {
+#if defined(_WIN32) && !defined(_XBOX) && !defined(UNICODE)
+      return mb_to_mb_string_alloc(str, CODEPAGE_LOCAL, CODEPAGE_UTF8);
+#else
+      /* assume string needs no modification if not on Windows */
+      return strdup(str);
+#endif
+   }
+   return NULL;
+}
+
+/* Returned pointer MUST be freed by the caller if non-NULL. */
+wchar_t* utf8_to_utf16_string_alloc(const char *str)
+{
+#ifdef _WIN32
+   int len        = 0;
+   int out_len    = 0;
+#else
+   size_t len     = 0;
+   size_t out_len = 0;
+#endif
+   wchar_t *buf   = NULL;
+
+   if (!str || !*str)
+      return NULL;
+
+#ifdef _WIN32
+   len = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
+
+   if (len)
+   {
+      buf = (wchar_t*)calloc(len, sizeof(wchar_t));
+
+      if (!buf)
+         return NULL;
+
+      out_len = MultiByteToWideChar(CP_UTF8, 0, str, -1, buf, len);
+   }
+   else
+   {
+      /* fallback to ANSI codepage instead */
+      len = MultiByteToWideChar(CP_ACP, 0, str, -1, NULL, 0);
+
+      if (len)
+      {
+         buf = (wchar_t*)calloc(len, sizeof(wchar_t));
+
+         if (!buf)
+            return NULL;
+
+         out_len = MultiByteToWideChar(CP_ACP, 0, str, -1, buf, len);
+      }
+   }
+
+   if (out_len < 0)
+   {
+      free(buf);
+      return NULL;
+   }
+#else
+   /* NOTE: For now, assume non-Windows platforms' locale is already UTF-8. */
+   len = mbstowcs(NULL, str, 0) + 1;
+
+   if (len)
+   {
+      buf = (wchar_t*)calloc(len, sizeof(wchar_t));
+
+      if (!buf)
+         return NULL;
+
+      out_len = mbstowcs(buf, str, len);
+   }
+
+   if (out_len == (size_t)-1)
+   {
+      free(buf);
+      return NULL;
+   }
+#endif
+
+   return buf;
+}
+
+/* Returned pointer MUST be freed by the caller if non-NULL. */
+char* utf16_to_utf8_string_alloc(const wchar_t *str)
+{
+#ifdef _WIN32
+   int len        = 0;
+#else
+   size_t len     = 0;
+#endif
+   char *buf      = NULL;
+
+   if (!str || !*str)
+      return NULL;
+
+#ifdef _WIN32
+   {
+      UINT code_page = CP_UTF8;
+      len            = WideCharToMultiByte(code_page,
+            0, str, -1, NULL, 0, NULL, NULL);
+
+      /* fallback to ANSI codepage instead */
+      if (!len)
+      {
+         code_page   = CP_ACP;
+         len         = WideCharToMultiByte(code_page,
+               0, str, -1, NULL, 0, NULL, NULL);
+      }
+
+      buf = (char*)calloc(len, sizeof(char));
+
+      if (!buf)
+         return NULL;
+
+      if (WideCharToMultiByte(code_page,
+            0, str, -1, buf, len, NULL, NULL) < 0)
+      {
+         free(buf);
+         return NULL;
+      }
+   }
+#else
+   /* NOTE: For now, assume non-Windows platforms' 
+    * locale is already UTF-8. */
+   len = wcstombs(NULL, str, 0) + 1;
+
+   if (len)
+   {
+      buf = (char*)calloc(len, sizeof(char));
+
+      if (!buf)
+         return NULL;
+
+      if (wcstombs(buf, str, len) == (size_t)-1)
+      {
+         free(buf);
+         return NULL;
+      }
+   }
+#endif
+
+   return buf;
+}

--- a/libretro-common/include/boolean.h
+++ b/libretro-common/include/boolean.h
@@ -1,7 +1,7 @@
 /* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
- * The following license statement only applies to this file (retro_inline.h).
+ * The following license statement only applies to this file (boolean.h).
  * ---------------------------------------------------------------------------------------
  *
  * Permission is hereby granted, free of charge,
@@ -20,20 +20,20 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef __LIBRETRO_SDK_INLINE_H
-#define __LIBRETRO_SDK_INLINE_H
+#ifndef __LIBRETRO_SDK_BOOLEAN_H
+#define __LIBRETRO_SDK_BOOLEAN_H
 
-#ifndef INLINE
+#ifndef __cplusplus
 
-#if defined(_WIN32) || defined(__INTEL_COMPILER)
-#define INLINE __inline
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__>=199901L
-#define INLINE inline
-#elif defined(__GNUC__)
-#define INLINE __inline__
+#if defined(_MSC_VER) && _MSC_VER < 1800 && !defined(SN_TARGET_PS3)
+/* Hack applied for MSVC when compiling in C89 mode as it isn't C99 compliant. */
+#define bool unsigned char
+#define true 1
+#define false 0
 #else
-#define INLINE
+#include <stdbool.h>
 #endif
 
 #endif
+
 #endif

--- a/libretro-common/include/compat/fopen_utf8.h
+++ b/libretro-common/include/compat/fopen_utf8.h
@@ -1,7 +1,7 @@
 /* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
- * The following license statement only applies to this file (retro_inline.h).
+ * The following license statement only applies to this file (fopen_utf8.h).
  * ---------------------------------------------------------------------------------------
  *
  * Permission is hereby granted, free of charge,
@@ -20,20 +20,15 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef __LIBRETRO_SDK_INLINE_H
-#define __LIBRETRO_SDK_INLINE_H
+#ifndef __LIBRETRO_SDK_COMPAT_FOPEN_UTF8_H
+#define __LIBRETRO_SDK_COMPAT_FOPEN_UTF8_H
 
-#ifndef INLINE
-
-#if defined(_WIN32) || defined(__INTEL_COMPILER)
-#define INLINE __inline
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__>=199901L
-#define INLINE inline
-#elif defined(__GNUC__)
-#define INLINE __inline__
+#ifdef _WIN32
+/* Defined to error rather than fopen_utf8, to make it clear to everyone reading the code that not worrying about utf16 is fine */
+/* TODO: enable */
+/* #define fopen (use fopen_utf8 instead) */
+void *fopen_utf8(const char * filename, const char * mode);
 #else
-#define INLINE
-#endif
-
+#define fopen_utf8 fopen
 #endif
 #endif

--- a/libretro-common/include/compat/strl.h
+++ b/libretro-common/include/compat/strl.h
@@ -1,0 +1,59 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (strl.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef __LIBRETRO_SDK_COMPAT_STRL_H
+#define __LIBRETRO_SDK_COMPAT_STRL_H
+
+#include <string.h>
+#include <stddef.h>
+
+#if defined(RARCH_INTERNAL) && defined(HAVE_CONFIG_H)
+#include "../../../config.h"
+#endif
+
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
+#ifdef __MACH__
+#ifndef HAVE_STRL
+#define HAVE_STRL
+#endif
+#endif
+
+#ifndef HAVE_STRL
+/* Avoid possible naming collisions during link since
+ * we prefer to use the actual name. */
+#define strlcpy(dst, src, size) strlcpy_retro__(dst, src, size)
+
+#define strlcat(dst, src, size) strlcat_retro__(dst, src, size)
+
+size_t strlcpy(char *dest, const char *source, size_t size);
+size_t strlcat(char *dest, const char *source, size_t size);
+
+#endif
+
+char *strldup(const char *s, size_t n);
+
+RETRO_END_DECLS
+
+#endif

--- a/libretro-common/include/encodings/utf.h
+++ b/libretro-common/include/encodings/utf.h
@@ -1,7 +1,7 @@
 /* Copyright  (C) 2010-2020 The RetroArch team
  *
  * ---------------------------------------------------------------------------------------
- * The following license statement only applies to this file (retro_inline.h).
+ * The following license statement only applies to this file (utf.h).
  * ---------------------------------------------------------------------------------------
  *
  * Permission is hereby granted, free of charge,
@@ -20,20 +20,48 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef __LIBRETRO_SDK_INLINE_H
-#define __LIBRETRO_SDK_INLINE_H
+#ifndef _LIBRETRO_ENCODINGS_UTF_H
+#define _LIBRETRO_ENCODINGS_UTF_H
 
-#ifndef INLINE
+#include <stdint.h>
+#include <stddef.h>
 
-#if defined(_WIN32) || defined(__INTEL_COMPILER)
-#define INLINE __inline
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__>=199901L
-#define INLINE inline
-#elif defined(__GNUC__)
-#define INLINE __inline__
-#else
-#define INLINE
-#endif
+#include <boolean.h>
 
-#endif
+#include <retro_common_api.h>
+
+RETRO_BEGIN_DECLS
+
+enum CodePage
+{
+   CODEPAGE_LOCAL = 0, /* CP_ACP */
+   CODEPAGE_UTF8  = 65001 /* CP_UTF8 */
+};
+
+size_t utf8_conv_utf32(uint32_t *out, size_t out_chars,
+      const char *in, size_t in_size);
+
+bool utf16_conv_utf8(uint8_t *out, size_t *out_chars,
+      const uint16_t *in, size_t in_size);
+
+size_t utf8len(const char *string);
+
+size_t utf8cpy(char *d, size_t d_len, const char *s, size_t chars);
+
+const char *utf8skip(const char *str, size_t chars);
+
+uint32_t utf8_walk(const char **string);
+
+bool utf16_to_char_string(const uint16_t *in, char *s, size_t len);
+
+char* utf8_to_local_string_alloc(const char *str);
+
+char* local_to_utf8_string_alloc(const char *str);
+
+wchar_t* utf8_to_utf16_string_alloc(const char *str);
+
+char* utf16_to_utf8_string_alloc(const wchar_t *str);
+
+RETRO_END_DECLS
+
 #endif

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -279,6 +279,10 @@ enum retro_language
    RETRO_LANGUAGE_GREEK               = 17,
    RETRO_LANGUAGE_TURKISH             = 18,
    RETRO_LANGUAGE_SLOVAK              = 19,
+   RETRO_LANGUAGE_PERSIAN             = 20,
+   RETRO_LANGUAGE_HEBREW              = 21,
+   RETRO_LANGUAGE_ASTURIAN            = 22,
+   RETRO_LANGUAGE_FINNISH             = 23,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -709,6 +713,9 @@ enum retro_mod
                                             * state of rumble motors in controllers.
                                             * A strong and weak motor is supported, and they can be
                                             * controlled indepedently.
+                                            * Should be called from either retro_init() or retro_load_game().
+                                            * Should not be called from retro_set_environment().
+                                            * Returns false if rumble functionality is unavailable.
                                             */
 #define RETRO_ENVIRONMENT_GET_INPUT_DEVICE_CAPABILITIES 24
                                            /* uint64_t * --
@@ -1316,6 +1323,59 @@ enum retro_mod
                                             * Should not be used for trivial messages, which should simply be
                                             * logged via RETRO_ENVIRONMENT_GET_LOG_INTERFACE (or as a
                                             * fallback, stderr).
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_INPUT_MAX_USERS 61
+                                           /* unsigned * --
+                                            * Unsigned value is the number of active input devices
+                                            * provided by the frontend. This may change between
+                                            * frames, but will remain constant for the duration
+                                            * of each frame.
+                                            * If callback returns true, a core need not poll any
+                                            * input device with an index greater than or equal to
+                                            * the number of active devices.
+                                            * If callback returns false, the number of active input
+                                            * devices is unknown. In this case, all input devices
+                                            * should be considered active.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK 62
+                                           /* const struct retro_audio_buffer_status_callback * --
+                                            * Lets the core know the occupancy level of the frontend
+                                            * audio buffer. Can be used by a core to attempt frame
+                                            * skipping in order to avoid buffer under-runs.
+                                            * A core may pass NULL to disable buffer status reporting
+                                            * in the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY 63
+                                           /* const unsigned * --
+                                            * Sets minimum frontend audio latency in milliseconds.
+                                            * Resultant audio latency may be larger than set value,
+                                            * or smaller if a hardware limit is encountered. A frontend
+                                            * is expected to honour requests up to 512 ms.
+                                            *
+                                            * - If value is less than current frontend
+                                            *   audio latency, callback has no effect
+                                            * - If value is zero, default frontend audio
+                                            *   latency is set
+                                            *
+                                            * May be used by a core to increase audio latency and
+                                            * therefore decrease the probability of buffer under-runs
+                                            * (crackling) when performing 'intensive' operations.
+                                            * A core utilising RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK
+                                            * to implement audio-buffer-based frame skipping may achieve
+                                            * optimal results by setting the audio latency to a 'high'
+                                            * (typically 6x or 8x) integer multiple of the expected
+                                            * frame time.
+                                            *
+                                            * WARNING: This can only be called from within retro_run().
+                                            * Calling this can require a full reinitialization of audio
+                                            * drivers in the frontend, so it is important to call it very
+                                            * sparingly, and usually only with the users explicit consent.
+                                            * An eventual driver reinitialize will happen so that audio
+                                            * callbacks happening after this call within the same retro_run()
+                                            * call will target the newly initialized driver.
                                             */
 
 /* VFS functionality */
@@ -2207,6 +2267,30 @@ struct retro_frame_time_callback
    retro_usec_t reference;
 };
 
+/* Notifies a libretro core of the current occupancy
+ * level of the frontend audio buffer.
+ *
+ * - active: 'true' if audio buffer is currently
+ *           in use. Will be 'false' if audio is
+ *           disabled in the frontend
+ *
+ * - occupancy: Given as a value in the range [0,100],
+ *              corresponding to the occupancy percentage
+ *              of the audio buffer
+ *
+ * - underrun_likely: 'true' if the frontend expects an
+ *                    audio buffer underrun during the
+ *                    next frame (indicates that a core
+ *                    should attempt frame skipping)
+ *
+ * It will be called right before retro_run() every frame. */
+typedef void (RETRO_CALLCONV *retro_audio_buffer_status_callback_t)(
+      bool active, unsigned occupancy, bool underrun_likely);
+struct retro_audio_buffer_status_callback
+{
+   retro_audio_buffer_status_callback_t callback;
+};
+
 /* Pass this to retro_video_refresh_t if rendering to hardware.
  * Passing NULL to retro_video_refresh_t is still a frame dupe as normal.
  * */
@@ -2655,7 +2739,7 @@ struct retro_input_descriptor
 struct retro_system_info
 {
    /* All pointers are owned by libretro implementation, and pointers must
-    * remain valid until retro_deinit() is called. */
+    * remain valid until it is unloaded. */
 
    const char *library_name;      /* Descriptive name of library. Should not
                                    * contain any version numbers, etc. */

--- a/libretro-common/include/retro_common_api.h
+++ b/libretro-common/include/retro_common_api.h
@@ -1,0 +1,119 @@
+/* Copyright  (C) 2010-2020 The RetroArch team
+ *
+ * ---------------------------------------------------------------------------------------
+ * The following license statement only applies to this file (retro_common_api.h).
+ * ---------------------------------------------------------------------------------------
+ *
+ * Permission is hereby granted, free of charge,
+ * to any person obtaining a copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef _LIBRETRO_COMMON_RETRO_COMMON_API_H
+#define _LIBRETRO_COMMON_RETRO_COMMON_API_H
+
+/*
+This file is designed to normalize the libretro-common compiling environment
+for public API headers. This should be leaner than a normal compiling environment,
+since it gets #included into other project's sources.
+*/
+
+/* ------------------------------------ */
+
+/*
+Ordinarily we want to put #ifdef __cplusplus extern "C" in C library
+headers to enable them to get used by c++ sources.
+However, we want to support building this library as C++ as well, so a
+special technique is called for.
+*/
+
+#define RETRO_BEGIN_DECLS
+#define RETRO_END_DECLS
+
+#ifdef __cplusplus
+
+#ifdef CXX_BUILD
+/* build wants everything to be built as c++, so no extern "C" */
+#else
+#undef RETRO_BEGIN_DECLS
+#undef RETRO_END_DECLS
+#define RETRO_BEGIN_DECLS extern "C" {
+#define RETRO_END_DECLS }
+#endif
+
+#else
+
+/* header is included by a C source file, so no extern "C" */
+
+#endif
+
+/*
+IMO, this non-standard ssize_t should not be used.
+However, it's a good example of how to handle something like this.
+*/
+#ifdef _MSC_VER
+#ifndef HAVE_SSIZE_T
+#define HAVE_SSIZE_T
+#if defined(_WIN64)
+typedef __int64 ssize_t;
+#elif defined(_WIN32)
+typedef int ssize_t;
+#endif
+#endif
+#elif defined(__MACH__)
+#include <sys/types.h>
+#endif
+
+#ifdef _MSC_VER
+#if _MSC_VER >= 1800
+#include <inttypes.h>
+#else
+#ifndef PRId64
+#define PRId64 "I64d"
+#define PRIu64 "I64u"
+#define PRIuPTR "Iu"
+#endif
+#endif
+#else
+/* C++11 says this one isn't needed, but apparently (some versions of) mingw require it anyways */
+/* https://stackoverflow.com/questions/8132399/how-to-printf-uint64-t-fails-with-spurious-trailing-in-format */
+/* https://github.com/libretro/RetroArch/issues/6009 */
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS 1
+#endif
+#include <inttypes.h>
+#endif
+#ifndef PRId64
+#error "inttypes.h is being screwy"
+#endif
+#define STRING_REP_INT64 "%" PRId64
+#define STRING_REP_UINT64 "%" PRIu64
+#define STRING_REP_USIZE "%" PRIuPTR
+
+/*
+I would like to see retro_inline.h moved in here; possibly boolean too.
+
+rationale: these are used in public APIs, and it is easier to find problems
+and write code that works the first time portably when theyre included uniformly
+than to do the analysis from scratch each time you think you need it, for each feature.
+
+Moreover it helps force you to make hard decisions: if you EVER bring in boolean.h,
+then you should pay the price everywhere, so you can see how much grief it will cause.
+
+Of course, another school of thought is that you should do as little damage as possible
+in as few places as possible...
+*/
+
+/* _LIBRETRO_COMMON_RETRO_COMMON_API_H */
+#endif

--- a/plugins/cdrcimg/cdrcimg.c
+++ b/plugins/cdrcimg/cdrcimg.c
@@ -8,6 +8,8 @@
  * See the COPYING file in the top-level directory.
  */
 
+#include <compat/fopen_utf8.h>
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -321,7 +323,7 @@ static long handle_eboot(void)
 	int i, ret;
 	FILE *f;
 
-	f = fopen(cd_fname, "rb");
+	f = fopen_utf8(cd_fname, "rb");
 	if (f == NULL) {
 		err("missing file: %s: ", cd_fname);
 		perror(NULL);
@@ -460,7 +462,7 @@ static long CDRopen(void)
 		return -1;
 	}
 
-	f = fopen(table_fname, "rb");
+	f = fopen_utf8(table_fname, "rb");
 	if (f == NULL) {
 		err("missing file: %s: ", table_fname);
 		perror(NULL);
@@ -525,7 +527,7 @@ static long CDRopen(void)
 		break;
 	}
 
-	cd_file = fopen(cd_fname, "rb");
+	cd_file = fopen_utf8(cd_fname, "rb");
 	if (cd_file == NULL) {
 		err("failed to open: %s: ", table_fname);
 		perror(NULL);


### PR DESCRIPTION
This selectively replace fopen calls with fopen_utf8, to handle paths
that uses special characters in Windows.

The replacement covers these:
- opening of bios file
- opening, writting and creating memcard2
- opening and handling of disk images

Related: https://github.com/libretro/libretro-fceumm/issues/448