### PR TITLE
libchdr: Use also fopen_utf8 here

### DIFF
--- a/deps/libchdr/include/libchdr/coretypes.h
+++ b/deps/libchdr/include/libchdr/coretypes.h
@@ -21,7 +21,12 @@ typedef int16_t INT16;
 typedef int8_t INT8;
 
 #define core_file FILE
+#ifdef HAVE_LIBRETRO
+#include <compat/fopen_utf8.h>
+#define core_fopen(file) fopen_utf8(file, "rb")
+#else
 #define core_fopen(file) fopen(file, "rb")
+#endif
 #if defined(__WIN32__) || defined(_WIN32) || defined(WIN32) || defined(__WIN64__)
 	#define core_fseek _fseeki64
 	#define core_ftell _ftelli64


### PR DESCRIPTION
RE: https://github.com/libretro/libretro-fceumm/issues/448

Minimal change to fix/resolve issues opening CHD files from paths with special character names