### PR TITLE
Do not compile debugger codes by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,13 +45,18 @@ CFLAGS += -DPCNT
 endif
 
 # core
-OBJS += libpcsxcore/cdriso.o libpcsxcore/cdrom.o libpcsxcore/cheat.o libpcsxcore/debug.o \
-	libpcsxcore/decode_xa.o libpcsxcore/disr3000a.o libpcsxcore/mdec.o \
+OBJS += libpcsxcore/cdriso.o libpcsxcore/cdrom.o libpcsxcore/cheat.o \
+	libpcsxcore/decode_xa.o libpcsxcore/mdec.o \
 	libpcsxcore/misc.o libpcsxcore/plugins.o libpcsxcore/ppf.o libpcsxcore/psxbios.o \
 	libpcsxcore/psxcommon.o libpcsxcore/psxcounters.o libpcsxcore/psxdma.o libpcsxcore/psxhle.o \
 	libpcsxcore/psxhw.o libpcsxcore/psxinterpreter.o libpcsxcore/psxmem.o libpcsxcore/r3000a.o \
-	libpcsxcore/sio.o libpcsxcore/socket.o libpcsxcore/spu.o
+	libpcsxcore/sio.o libpcsxcore/spu.o
 OBJS += libpcsxcore/gte.o libpcsxcore/gte_nf.o libpcsxcore/gte_divider.o
+
+ifeq ($(DEBUG), 1)
+OBJS += libpcsxcore/debug.o	libpcsxcore/socket.o libpcsxcore/disr3000a.o
+endif
+
 ifeq ($(WANT_ZLIB),1)
 CFLAGS += -Ideps/libchdr/deps/zlib-1.2.11
 OBJS += deps/libchdr/deps/zlib-1.2.11/adler32.o \

--- a/libpcsxcore/psxinterpreter.c
+++ b/libpcsxcore/psxinterpreter.c
@@ -39,6 +39,12 @@ static u32 branchPC;
 #define debugI()
 #endif
 
+#ifdef NDEBUG
+void StartDebugger() {}
+void ProcessDebug() {}
+void StopDebugger() {}
+#endif
+
 void execI();
 
 // Subsets

--- a/libpcsxcore/psxmem.c
+++ b/libpcsxcore/psxmem.c
@@ -39,6 +39,10 @@
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
+#ifdef NDEBUG
+void DebugCheckBP(u32 address, enum breakpoint_types type) {}
+#endif
+
 void *(*psxMapHook)(unsigned long addr, size_t size, int is_fixed,
 		enum psxMapTag tag);
 void (*psxUnmapHook)(void *ptr, size_t size, enum psxMapTag tag);


### PR DESCRIPTION
- Reduces binary to about half the size
- These are mostly breakpoints anyways, which atm there is no way to interface with frontend for debugger needs.
- Compile with DEBUG=1 to build core with debug code
