### PR TITLE
Handle DIV overflow in lightrec and the interpreter

### DIFF
--- a/deps/lightrec/interpreter.c
+++ b/deps/lightrec/interpreter.c
@@ -801,6 +801,9 @@ static u32 int_special_DIV(struct interpreter *inter)
 	if (rt == 0) {
 		hi = rs;
 		lo = (rs < 0) * 2 - 1;
+	} else if ((rs == 0x80000000) && (rt == 0xFFFFFFFF)) {
+		lo = rs;
+		hi = 0;
 	} else {
 		lo = rs / rt;
 		hi = rs % rt;

--- a/libpcsxcore/psxinterpreter.c
+++ b/libpcsxcore/psxinterpreter.c
@@ -507,14 +507,20 @@ void psxSLTU() 	{ if (!_Rd_) return; _rRd_ = _u32(_rRs_) < _u32(_rRt_); }	// Rd 
 * Format:  OP rs, rt                                     *
 *********************************************************/
 void psxDIV() {
-	if (_i32(_rRt_) != 0) {
-		_i32(_rLo_) = _i32(_rRs_) / _i32(_rRt_);
-		_i32(_rHi_) = _i32(_rRs_) % _i32(_rRt_);
-	}
-	else {
-		_i32(_rLo_) = _i32(_rRs_) >= 0 ? 0xffffffff : 1;
-		_i32(_rHi_) = _i32(_rRs_);
-	}
+    if (!_i32(_rRt_)) {
+        _i32(_rHi_) = _i32(_rRs_);
+        if (_i32(_rRs_) & 0x80000000) {
+            _i32(_rLo_) = 1;
+        } else {
+            _i32(_rLo_) = 0xFFFFFFFF;
+        }
+    } else if (_i32(_rRs_) == 0x80000000 && _i32(_rRt_) == 0xFFFFFFFF) {
+        _i32(_rLo_) = 0x80000000;
+        _i32(_rHi_) = 0;
+    } else {
+        _i32(_rLo_) = _i32(_rRs_) / _i32(_rRt_);
+        _i32(_rHi_) = _i32(_rRs_) % _i32(_rRt_);
+    }
 }
 
 void psxDIVU() {


### PR DESCRIPTION
This PR handles an undocumented edge case of division overflow in the DIV instruction both in lightrec and the interpreter. Without this patch, guest code will get unexpected results, and may even crash the core on x86, as AmiDog's basic CPU test shows.