### PR TITLE
Fix initialization on Frontends without variable support.

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1634,7 +1634,9 @@ static void update_variables(bool in_flight)
    var.value = NULL;
    var.key = "pcsx_rearmed_drc";
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var))
+      var.value = "enabled";
+
    {
       R3000Acpu *prev_cpu = psxCpu;
 #if defined(LIGHTREC)


### PR DESCRIPTION
Frontends that do not support RETRO_ENVIRONMENT_GET_VARIABLE (like
miniretro & nanoarch) cause a segfault in the CPU emulation path unless
the BIOS file is present. This is due to the emulator not supporting
running without a BIOS in dynarec mode and the code not being able to
swap CPU types (unless the callback returns true).