### PR TITLE
CDRom timings changes

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -496,6 +496,7 @@ void cdrPlayInterrupt()
 		if (cdr.SetlocPending) {
 			memcpy(cdr.SetSectorPlay, cdr.SetSector, 4);
 			cdr.SetlocPending = 0;
+			cdr.m_locationChanged = TRUE;
 		}
 		Find_CurTrack(cdr.SetSectorPlay);
 		ReadTrack(cdr.SetSectorPlay);
@@ -527,7 +528,15 @@ void cdrPlayInterrupt()
 		}
 	}
 
-	CDRMISC_INT(cdReadTime);
+	if (cdr.m_locationChanged)
+	{
+		CDRMISC_INT(cdReadTime * 30);
+		cdr.m_locationChanged = FALSE;
+	}
+	else
+	{
+		CDRMISC_INT(cdReadTime);
+	}
 
 	// update for CdlGetlocP/autopause
 	generate_subq(cdr.SetSectorPlay);
@@ -589,6 +598,7 @@ void cdrInterrupt() {
 			if (cdr.SetlocPending) {
 				memcpy(cdr.SetSectorPlay, cdr.SetSector, 4);
 				cdr.SetlocPending = 0;
+				cdr.m_locationChanged = TRUE;
 			}
 
 			// BIOS CD Player
@@ -914,6 +924,7 @@ void cdrInterrupt() {
 				if(seekTime > 1000000) seekTime = 1000000;
 				memcpy(cdr.SetSectorPlay, cdr.SetSector, 4);
 				cdr.SetlocPending = 0;
+				cdr.m_locationChanged = TRUE;
 			}
 			Find_CurTrack(cdr.SetSectorPlay);
 
@@ -1130,7 +1141,13 @@ void cdrReadInterrupt() {
 
 	cdr.Readed = 0;
 
-	CDREAD_INT((cdr.Mode & MODE_SPEED) ? (cdReadTime / 2) : cdReadTime);
+	uint32_t delay = (cdr.Mode & MODE_SPEED) ? (cdReadTime / 2) : cdReadTime;
+	if (cdr.m_locationChanged) {
+		CDREAD_INT(delay * 30);
+		cdr.m_locationChanged = FALSE;
+	} else {
+		CDREAD_INT(delay);
+	}
 
 	/*
 	Croc 2: $40 - only FORM1 (*)
@@ -1468,6 +1485,8 @@ void cdrReset() {
 	cdr.DriveState = DRIVESTATE_STANDBY;
 	cdr.StatP = STATUS_ROTATING;
 	pTransfer = cdr.Transfer;
+	cdr.SetlocPending = 0;
+	cdr.m_locationChanged = FALSE;
 
 	// BIOS player - default values
 	cdr.AttenuatorLeftToLeft = 0x80;

--- a/libpcsxcore/cdrom.h
+++ b/libpcsxcore/cdrom.h
@@ -83,6 +83,7 @@ typedef struct {
 	unsigned char SetSector[4];
 	unsigned char Track;
 	boolean Play, Muted;
+	boolean m_locationChanged;
 	int CurTrack;
 	int Mode, File, Channel;
 	int Reset;


### PR DESCRIPTION
Upstreamed changes from PCSX Redux as seen here :
https://github.com/grumpycoders/pcsx-redux/commit/5730e04f0183f37038bc1d133cf9f9092425b90a

This apparently fixes Deus Fight in Xenogears and it was reported to fix the freeze after Lunar Cry FMV in Final Fantasy 8.
(It also seemingly fixed the desync issue in CTR's intro although i'm not sure if it was that fix or https://github.com/notaz/pcsx_rearmed/pull/183)

I have not noticed any regressions so far (and the redux project has not it seems either) but feel free to test.