### PR TITLE
Sort out compiler warnings, all of them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,9 @@ CXXFLAGS += $(CFLAGS)
 #DRC_DBG = 1
 #PCNT = 1
 
+# Suppress minor warnings for dependencies
+deps/%: CFLAGS += -Wno-unused -Wno-unused-function
+
 all: config.mak target_ plugins_
 
 ifndef NO_CONFIG_MAK

--- a/deps/libchdr/include/libchdr/coretypes.h
+++ b/deps/libchdr/include/libchdr/coretypes.h
@@ -44,6 +44,9 @@ typedef int8_t INT8;
 #define core_fclose fclose
 #endif
 
+#ifdef __GNUC__
+__attribute__ ((unused))
+#endif
 static UINT64 core_fsize(core_file *f)
 {
     UINT64 rv;

--- a/deps/lightning/lib/jit_print.c
+++ b/deps/lightning/lib/jit_print.c
@@ -280,12 +280,12 @@ _jit_print_node(jit_state_t *_jit, jit_node_t *node)
 	case jit_code_name:
 	    print_chr(' ');
 	    if (node->v.p && _jitc->emit)
-		print_str(node->v.n->u.p);
+		print_ptr(node->v.n->u.p);
 	    break;
 	case jit_code_note:
 	    print_chr(' ');
 	    if (node->v.p && _jitc->emit)
-		print_str(node->v.n->u.p);
+		print_ptr(node->v.n->u.p);
 	    if (node->v.p && _jitc->emit && node->w.w)
 		print_chr(':');
 	    if (node->w.w)

--- a/deps/lightrec/emitter.c
+++ b/deps/lightrec/emitter.c
@@ -900,7 +900,7 @@ static void rec_store_direct(const struct block *block, const struct opcode *op,
 	struct lightrec_state *state = block->state;
 	struct regcache *reg_cache = state->reg_cache;
 	jit_state_t *_jit = block->_jit;
-	jit_node_t *to_not_ram, *to_end;
+	jit_node_t *to_not_ram, *to_end = 0;
 	u8 tmp, tmp2, tmp3, rs, rt;
 
 	jit_note(__FILE__, __LINE__);
@@ -1016,7 +1016,7 @@ static void rec_load_direct(const struct block *block, const struct opcode *op,
 	struct lightrec_state *state = block->state;
 	struct regcache *reg_cache = state->reg_cache;
 	jit_state_t *_jit = block->_jit;
-	jit_node_t *to_not_ram, *to_not_bios, *to_end, *to_end2;
+	jit_node_t *to_not_ram, *to_not_bios = 0, *to_end, *to_end2;
 	u8 tmp, rs, rt, addr_reg;
 	s16 imm;
 

--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1337,14 +1337,12 @@ bool retro_load_game(const struct retro_game_info *info)
 
       for (i = 0; i < sizeof(disks) / sizeof(disks[0]) && i < cdrIsoMultidiskCount; i++)
       {
-         char disk_name[PATH_MAX];
-         char disk_label[PATH_MAX];
-         disk_name[0] = '\0';
-         disk_label[0] = '\0';
+         char disk_name[PATH_MAX - 16] = { 0 };
+         char disk_label[PATH_MAX] = { 0 };
 
          disks[i].fname = strdup(info->path);
 
-         get_disk_label(disk_name, info->path, PATH_MAX);
+         get_disk_label(disk_name, info->path, sizeof(disk_name));
          snprintf(disk_label, sizeof(disk_label), "%s #%u", disk_name, (unsigned)i + 1);
          disks[i].flabel = strdup(disk_label);
 
@@ -2776,7 +2774,8 @@ void retro_init(void)
 #ifdef _3DS
    vout_buf = linearMemAlign(VOUT_MAX_WIDTH * VOUT_MAX_HEIGHT * 2, 0x80);
 #elif defined(_POSIX_C_SOURCE) && (_POSIX_C_SOURCE >= 200112L) && !defined(VITA) && !defined(__SWITCH__)
-   posix_memalign(&vout_buf, 16, VOUT_MAX_WIDTH * VOUT_MAX_HEIGHT * 2);
+   if (posix_memalign(&vout_buf, 16, VOUT_MAX_WIDTH * VOUT_MAX_HEIGHT * 2) != 0)
+      vout_buf = (void *) 0;
 #else
    vout_buf = malloc(VOUT_MAX_WIDTH * VOUT_MAX_HEIGHT * 2);
 #endif

--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -50,6 +50,7 @@
 #define ftello rftell
 #define fseeko rfseek
 #endif
+
 #define OFF_T_MSB ((off_t)1 << (sizeof(off_t) * 8 - 1))
 
 unsigned int cdrIsoMultidiskCount;
@@ -359,11 +360,12 @@ static int parsetoc(const char *isofile) {
 			}
 		}
 		// check if it's really a TOC named as a .cue
-		fgets(linebuf, sizeof(linebuf), fi);
-		token = strtok(linebuf, " ");
-		if (token && strncmp(token, "CD", 2) != 0 && strcmp(token, "CATALOG") != 0) {
-			fclose(fi);
-			return -1;
+		if (fgets(linebuf, sizeof(linebuf), fi) != NULL) {
+			token = strtok(linebuf, " ");
+			if (token && strncmp(token, "CD", 2) != 0 && strcmp(token, "CATALOG") != 0) {
+				fclose(fi);
+				return -1;
+			}
 		}
 		fseek(fi, 0, SEEK_SET);
 	}
@@ -718,7 +720,8 @@ static int parsemds(const char *isofile) {
 	memset(&ti, 0, sizeof(ti));
 
 	// check if it's a valid mds file
-	fread(&i, 1, sizeof(unsigned int), fi);
+	if (fread(&i, 1, sizeof(i), fi) != sizeof(i))
+		goto fail_io;
 	i = SWAP32(i);
 	if (i != 0x4944454D) {
 		// not an valid mds file
@@ -728,19 +731,22 @@ static int parsemds(const char *isofile) {
 
 	// get offset to session block
 	fseek(fi, 0x50, SEEK_SET);
-	fread(&offset, 1, sizeof(unsigned int), fi);
+	if (fread(&offset, 1, sizeof(offset), fi) != sizeof(offset))
+		goto fail_io;
 	offset = SWAP32(offset);
 
 	// get total number of tracks
 	offset += 14;
 	fseek(fi, offset, SEEK_SET);
-	fread(&s, 1, sizeof(unsigned short), fi);
+	if (fread(&s, 1, sizeof(s), fi) != sizeof(s))
+		goto fail_io;
 	s = SWAP16(s);
 	numtracks = s;
 
 	// get offset to track blocks
 	fseek(fi, 4, SEEK_CUR);
-	fread(&offset, 1, sizeof(unsigned int), fi);
+	if (fread(&offset, 1, sizeof(offset), fi) != sizeof(offset))
+		goto fail_io;
 	offset = SWAP32(offset);
 
 	// skip lead-in data
@@ -769,32 +775,41 @@ static int parsemds(const char *isofile) {
 		ti[i].start[1] = fgetc(fi);
 		ti[i].start[2] = fgetc(fi);
 
-		fread(&extra_offset, 1, sizeof(unsigned int), fi);
+		if (fread(&extra_offset, 1, sizeof(extra_offset), fi) != sizeof(extra_offset))
+			goto fail_io;
 		extra_offset = SWAP32(extra_offset);
 
 		// get track start offset (in .mdf)
 		fseek(fi, offset + 0x28, SEEK_SET);
-		fread(&l, 1, sizeof(unsigned int), fi);
+		if (fread(&l, 1, sizeof(l), fi) != sizeof(l))
+			goto fail_io;
 		l = SWAP32(l);
 		ti[i].start_offset = l;
 
 		// get pregap
 		fseek(fi, extra_offset, SEEK_SET);
-		fread(&l, 1, sizeof(unsigned int), fi);
+		if (fread(&l, 1, sizeof(l), fi) != sizeof(l))
+			goto fail_io;
 		l = SWAP32(l);
 		if (l != 0 && i > 1)
 			pregapOffset = msf2sec(ti[i].start);
 
 		// get the track length
-		fread(&l, 1, sizeof(unsigned int), fi);
+		if (fread(&l, 1, sizeof(l), fi) != sizeof(l))
+			goto fail_io;
 		l = SWAP32(l);
 		sec2msf(l, ti[i].length);
 
 		offset += 0x50;
 	}
-
 	fclose(fi);
 	return 0;
+fail_io:
+#ifndef NDEBUG
+	SysPrintf(_("File IO error in <%s:%s>.\n"), __FILE__, __func__);
+#endif
+	fclose(fi);
+	return -1;
 }
 
 static int handlepbp(const char *isofile) {
@@ -845,7 +860,8 @@ static int handlepbp(const char *isofile) {
 	}
 
 	psisoimg_offs = pbp_hdr.psar_offs;
-	fread(psar_sig, 1, sizeof(psar_sig), cdHandle);
+	if (fread(psar_sig, 1, sizeof(psar_sig), cdHandle) != sizeof(psar_sig))
+		goto fail_io;
 	psar_sig[10] = 0;
 	if (strcmp(psar_sig, "PSTITLEIMG") == 0) {
 		// multidisk image?
@@ -881,7 +897,8 @@ static int handlepbp(const char *isofile) {
 			goto fail_io;
 		}
 
-		fread(psar_sig, 1, sizeof(psar_sig), cdHandle);
+		if (fread(psar_sig, 1, sizeof(psar_sig), cdHandle) != sizeof(psar_sig))
+			goto fail_io;
 		psar_sig[10] = 0;
 	}
 
@@ -899,15 +916,18 @@ static int handlepbp(const char *isofile) {
 
 	// first 3 entries are special
 	fseek(cdHandle, sizeof(toc_entry), SEEK_CUR);
-	fread(&toc_entry, 1, sizeof(toc_entry), cdHandle);
+	if (fread(&toc_entry, 1, sizeof(toc_entry), cdHandle) != sizeof(toc_entry))
+		goto fail_io;
 	numtracks = btoi(toc_entry.index1[0]);
 
-	fread(&toc_entry, 1, sizeof(toc_entry), cdHandle);
+	if (fread(&toc_entry, 1, sizeof(toc_entry), cdHandle) != sizeof(toc_entry))
+		goto fail_io;
 	cd_length = btoi(toc_entry.index1[0]) * 60 * 75 +
 		btoi(toc_entry.index1[1]) * 75 + btoi(toc_entry.index1[2]);
 
 	for (i = 1; i <= numtracks; i++) {
-		fread(&toc_entry, 1, sizeof(toc_entry), cdHandle);
+		if (fread(&toc_entry, 1, sizeof(toc_entry), cdHandle) != sizeof(toc_entry))
+			goto fail_io;
 
 		ti[i].type = (toc_entry.type == 1) ? CDDA : DATA;
 
@@ -965,7 +985,14 @@ static int handlepbp(const char *isofile) {
 fail_index:
 	free(compr_img->index_table);
 	compr_img->index_table = NULL;
+	goto done;
+
 fail_io:
+#ifndef NDEBUG
+	SysPrintf(_("File IO error in <%s:%s>.\n"), __FILE__, __func__);
+#endif
+
+done:
 	if (compr_img != NULL) {
 		free(compr_img);
 		compr_img = NULL;
@@ -1388,10 +1415,18 @@ static int cdread_sub_mixed(FILE *f, unsigned int base, void *dest, int sector)
 
 	fseek(f, base + sector * (CD_FRAMESIZE_RAW + SUB_FRAMESIZE), SEEK_SET);
 	ret = fread(dest, 1, CD_FRAMESIZE_RAW, f);
-	fread(subbuffer, 1, SUB_FRAMESIZE, f);
+	if (fread(subbuffer, 1, SUB_FRAMESIZE, f) != SUB_FRAMESIZE)
+		goto fail_io;
 
 	if (subChanRaw) DecodeRawSubData();
+	goto done;
 
+fail_io:
+#ifndef NDEBUG
+	SysPrintf(_("File IO error in <%s:%s>.\n"), __FILE__, __func__);
+#endif
+
+done:
 	return ret;
 }
 
@@ -1719,7 +1754,12 @@ static long CALLBACK ISOopen(void) {
 	if (ftello(cdHandle) % 2048 == 0) {
 		unsigned int modeTest = 0;
 		fseek(cdHandle, 0, SEEK_SET);
-		fread(&modeTest, 4, 1, cdHandle);
+		if (fread(&modeTest, sizeof(modeTest), 1, cdHandle) != sizeof(modeTest)) {
+#ifndef NDEBUG
+			SysPrintf(_("File IO error in <%s:%s>.\n"), __FILE__, __func__);
+#endif
+			return -1;
+		}
 		if (SWAP32(modeTest) != 0xffffff00) {
 			strcat(image_str, "[2048]");
 			isMode1ISO = TRUE;
@@ -1898,7 +1938,9 @@ static long CALLBACK ISOreadTrack(unsigned char *time) {
 
 	if (subHandle != NULL) {
 		fseek(subHandle, sector * SUB_FRAMESIZE, SEEK_SET);
-		fread(subbuffer, 1, SUB_FRAMESIZE, subHandle);
+		if (fread(subbuffer, 1, SUB_FRAMESIZE, subHandle) != SUB_FRAMESIZE)
+			/* Faulty subchannel data shouldn't cause a read failure */
+			return 0;
 
 		if (subChanRaw) DecodeRawSubData();
 	}

--- a/libpcsxcore/disr3000a.c
+++ b/libpcsxcore/disr3000a.c
@@ -73,17 +73,17 @@ typedef char* (*TdisR3000AF)(u32 code, u32 pc);
 #define _Branch_  (pc + 4 + ((short)_Im_ * 4))
 #define _OfB_     _Im_, _nRs_
 
-#define dName(i)	sprintf(ostr, "%s %-7s,", ostr, i)
-#define dGPR(i)		sprintf(ostr, "%s %8.8x (%s),", ostr, psxRegs.GPR.r[i], disRNameGPR[i])
-#define dCP0(i)		sprintf(ostr, "%s %8.8x (%s),", ostr, psxRegs.CP0.r[i], disRNameCP0[i])
-#define dHI()		sprintf(ostr, "%s %8.8x (%s),", ostr, psxRegs.GPR.n.hi, "hi")
-#define dLO()		sprintf(ostr, "%s %8.8x (%s),", ostr, psxRegs.GPR.n.lo, "lo")
-#define dImm()		sprintf(ostr, "%s %4.4x (%d),", ostr, _Im_, _Im_)
-#define dTarget()	sprintf(ostr, "%s %8.8x,", ostr, _Target_)
-#define dSa()		sprintf(ostr, "%s %2.2x (%d),", ostr, _Sa_, _Sa_)
-#define dOfB()		sprintf(ostr, "%s %4.4x (%8.8x (%s)),", ostr, _Im_, psxRegs.GPR.r[_Rs_], disRNameGPR[_Rs_])
-#define dOffset()	sprintf(ostr, "%s %8.8x,", ostr, _Branch_)
-#define dCode()		sprintf(ostr, "%s %8.8x,", ostr, (code >> 6) & 0xffffff)
+#define dName(i)	snprintf(ostr, sizeof(ostr), "%s %-7s,", ostr, i)
+#define dGPR(i)		snprintf(ostr, sizeof(ostr), "%s %8.8x (%s),", ostr, psxRegs.GPR.r[i], disRNameGPR[i])
+#define dCP0(i)		snprintf(ostr, sizeof(ostr), "%s %8.8x (%s),", ostr, psxRegs.CP0.r[i], disRNameCP0[i])
+#define dHI()		snprintf(ostr, sizeof(ostr), "%s %8.8x (%s),", ostr, psxRegs.GPR.n.hi, "hi")
+#define dLO()		snprintf(ostr, sizeof(ostr), "%s %8.8x (%s),", ostr, psxRegs.GPR.n.lo, "lo")
+#define dImm()		snprintf(ostr, sizeof(ostr), "%s %4.4x (%d),", ostr, _Im_, _Im_)
+#define dTarget()	snprintf(ostr, sizeof(ostr), "%s %8.8x,", ostr, _Target_)
+#define dSa()		snprintf(ostr, sizeof(ostr), "%s %2.2x (%d),", ostr, _Sa_, _Sa_)
+#define dOfB()		snprintf(ostr, sizeof(ostr), "%s %4.4x (%8.8x (%s)),", ostr, _Im_, psxRegs.GPR.r[_Rs_], disRNameGPR[_Rs_])
+#define dOffset()	snprintf(ostr, sizeof(ostr), "%s %8.8x,", ostr, _Branch_)
+#define dCode()		snprintf(ostr, sizeof(ostr), "%s %8.8x,", ostr, (code >> 6) & 0xffffff)
 
 /*********************************************************
 * Arithmetic with immediate operand                      *

--- a/libpcsxcore/lightrec/plugin.c
+++ b/libpcsxcore/lightrec/plugin.c
@@ -401,11 +401,11 @@ static int lightrec_plugin_init(void)
 			lightrec_map, ARRAY_SIZE(lightrec_map),
 			&lightrec_ops);
 
-	fprintf(stderr, "M=0x%lx, P=0x%lx, R=0x%lx, H=0x%lx\n",
-			(uintptr_t) psxM,
-			(uintptr_t) psxP,
-			(uintptr_t) psxR,
-			(uintptr_t) psxH);
+	// fprintf(stderr, "M=0x%lx, P=0x%lx, R=0x%lx, H=0x%lx\n",
+	// 		(uintptr_t) psxM,
+	// 		(uintptr_t) psxP,
+	// 		(uintptr_t) psxR,
+	// 		(uintptr_t) psxH);
 
 #ifndef _WIN32
 	signal(SIGPIPE, exit);

--- a/libpcsxcore/psxinterpreter.c
+++ b/libpcsxcore/psxinterpreter.c
@@ -39,7 +39,9 @@ static u32 branchPC;
 #define debugI()
 #endif
 
-#ifdef NDEBUG
+#ifndef NDEBUG
+#include "debug.h"
+#else
 void StartDebugger() {}
 void ProcessDebug() {}
 void StopDebugger() {}

--- a/libpcsxcore/sio.c
+++ b/libpcsxcore/sio.c
@@ -454,7 +454,12 @@ void LoadMcd(int mcd, char *str) {
 				else if(buf.st_size == MCD_SIZE + 3904)
 					fseek(f, 3904, SEEK_SET);
 			}
-			fread(data, 1, MCD_SIZE, f);
+			if (fread(data, 1, MCD_SIZE, f) != MCD_SIZE) {
+#ifndef NDEBUG
+				SysPrintf(_("File IO error in <%s:%s>.\n"), __FILE__, __func__);
+#endif
+				memset(data, 0x00, MCD_SIZE);
+			}
 			fclose(f);
 		}
 		else
@@ -469,7 +474,12 @@ void LoadMcd(int mcd, char *str) {
 			else if(buf.st_size == MCD_SIZE + 3904)
 				fseek(f, 3904, SEEK_SET);
 		}
-		fread(data, 1, MCD_SIZE, f);
+		if (fread(data, 1, MCD_SIZE, f) != MCD_SIZE) {
+#ifndef NDEBUG
+			SysPrintf(_("File IO error in <%s:%s>.\n"), __FILE__, __func__);
+#endif
+			memset(data, 0x00, MCD_SIZE);
+		}
 		fclose(f);
 	}
 }

--- a/plugins/dfsound/out.c
+++ b/plugins/dfsound/out.c
@@ -47,6 +47,6 @@ void SetupSound(void)
 	}
 
 	out_current = &out_drivers[i];
-	printf("selected sound output driver: %s\n", out_current->name);
+	// printf("selected sound output driver: %s\n", out_current->name);
 }
 


### PR DESCRIPTION
PCSX spams a lot of warnings while it's built using GCC, and they are very distracting during development. This PR removes all of them, the hard way: IO warnings (most of them about unchecked freads) by adding extra checks, printf overflow warnings by switching to snprintf, unused functions and variables warnings by disabling those for the deps folder, and others mostly by initializing vars in undecidable functions and by fixing minor bugs. Only a single warning indicated a bug - that one I marked with a TODO for later.

Some extras included:
- A pair of stray debug printfs were removed, one in lightrec, the other in dfxsound.
- Debug builds previously failing because of name conflicts between debug functions and their stubs are restored.
- IO errors are now reported using OSD messages in debug builds.

This PR doesn't introduce any new features, and may have bugs of its own, but as it's benefical for further development, I believe it's worth the risk. It's possible I'll do a follow-up once I do a valgrind run.