### PR TITLE
Fix save state compatibility that was broken by my CDrom timing changes.

### DIFF
--- a/libpcsxcore/cdrom.h
+++ b/libpcsxcore/cdrom.h
@@ -59,7 +59,8 @@ typedef struct {
 		unsigned char Absolute[3];
 	} subq;
 	unsigned char TrackChanged;
-	unsigned char pad1[3];
+	boolean m_locationChanged;
+	unsigned char pad1[2];
 	unsigned int  freeze_ver;
 
 	unsigned char Prev[4];
@@ -83,7 +84,6 @@ typedef struct {
 	unsigned char SetSector[4];
 	unsigned char Track;
 	boolean Play, Muted;
-	boolean m_locationChanged;
 	int CurTrack;
 	int Mode, File, Channel;
 	int Reset;


### PR DESCRIPTION
Notaz pointed that to me that the way i put my variable inside the structure broke save state compatibility. https://github.com/notaz/pcsx_rearmed/pull/184#pullrequestreview-731139926
He suggested using one of the pad members instead, which i have just done instead.

I'll probably wait for him to confirm if it's good but i think it's the right way.