### PR TITLE
Properly protect the HLE instructions against corrupted memory.

### DIFF
--- a/libpcsxcore/new_dynarec/new_dynarec.c
+++ b/libpcsxcore/new_dynarec/new_dynarec.c
@@ -3489,7 +3489,11 @@ void hlecall_assemble(int i,struct regstat *i_regs)
   assert(!is_delayslot);
   (void)ccreg;
   emit_movimm(start+i*4+4,0); // Get PC
-  emit_movimm((int)psxHLEt[source[i]&7],1);
+  uint32_t hleCode = source[i] & 0x03ffffff;
+  if (hleCode >= (sizeof(psxHLEt) / sizeof(psxHLEt[0])))
+    emit_movimm((int)psxNULL,1);
+  else
+    emit_movimm((int)psxHLEt[hleCode],1);
   emit_addimm(HOST_CCREG,CLOCK_ADJUST(ccadj[i]),HOST_CCREG); // XXX
   emit_jmp((int)jump_hlecall);
 }

--- a/libpcsxcore/psxhle.c
+++ b/libpcsxcore/psxhle.c
@@ -95,7 +95,7 @@ static void hleExecRet() {
 	psxRegs.pc = psxRegs.GPR.n.ra;
 }
 
-void (*psxHLEt[256])() = {
+const void (*psxHLEt[8])() = {
 	hleDummy, hleA0, hleB0, hleC0,
 	hleBootstrap, hleExecRet,
 	hleDummy, hleDummy

--- a/libpcsxcore/psxhle.h
+++ b/libpcsxcore/psxhle.h
@@ -28,7 +28,7 @@ extern "C" {
 #include "r3000a.h"
 #include "plugins.h"
 
-extern void (*psxHLEt[256])();
+extern const void (*psxHLEt[8])();
 
 #ifdef __cplusplus
 }

--- a/libpcsxcore/psxinterpreter.c
+++ b/libpcsxcore/psxinterpreter.c
@@ -856,7 +856,13 @@ void psxBASIC(struct psxCP2Regs *regs) {
 
 void psxHLE() {
 //	psxHLEt[psxRegs.code & 0xffff]();
-	psxHLEt[psxRegs.code & 0x07]();		// HDHOSHY experimental patch
+//	psxHLEt[psxRegs.code & 0x07]();		// HDHOSHY experimental patch
+    uint32_t hleCode = psxRegs.code & 0x03ffffff;
+    if (hleCode >= (sizeof(psxHLEt) / sizeof(psxHLEt[0]))) {
+        psxNULL();
+    } else {
+        psxHLEt[hleCode]();
+    }
 }
 
 void (*psxBSC[64])() = {


### PR DESCRIPTION
Fix is from PCSX-redux :
https://github.com/grumpycoders/pcsx-redux/commit/99c9508f2a9dc1444b88f37eb100cdfb17862b52

This should hopefully fix HDHOSHY's experimental patch properly.
I'm not so sure about my code for the dynarec however but it is a direct equivalent to the interpreter's.

One instance when this does happen is Nuclear Strike over HLE when attempting to load a save.
```
#0  0x0000555555595e55 in psxBranchNoDelay ()
    at libpcsxcore/psxinterpreter.c:293
#1  0x00005555555962c9 in psxDelayBranchTest (tar1=160)
    at libpcsxcore/psxinterpreter.c:369
#2  0x0000555555596386 in doBranch (tar=160)
    at libpcsxcore/psxinterpreter.c:419
#3  0x00005555555977b4 in psxJR () at libpcsxcore/psxinterpreter.c:629
#4  0x00005555555981c2 in psxSPECIAL () at libpcsxcore/psxinterpreter.c:824
#5  0x00005555555983f0 in execI () at libpcsxcore/psxinterpreter.c:942
#6  0x00005555555982fe in intExecuteBlock ()
    at libpcsxcore/psxinterpreter.c:921
#7  0x000055555558836c in softCall2 (pc=2148158980)
    at libpcsxcore/psxbios.c:299
#8  0x0000555555588412 in DeliverEvent (ev=17, spec=2)
    at libpcsxcore/psxbios.c:310
#9  0x000055555558cc21 in psxBios__card_info () at libpcsxcore/psxbios.c:1598
#10 0x0000555555594151 in hleA0 () at libpcsxcore/psxhle.c:35
#11 0x00005555555982b1 in psxHLE () at libpcsxcore/psxinterpreter.c:845
#12 0x00005555555983f0 in execI () at libpcsxcore/psxinterpreter.c:942
#13 0x00005555555982fe in intExecuteBlock ()
    at libpcsxcore/psxinterpreter.c:921
#14 0x000055555558836c in softCall2 (pc=214815
```
With this patch, it still won't work but at least the game won't crash anymore. (it will just freeze)

The dynarec code was corrected as said per notaz's advice. (See here : https://github.com/notaz/pcsx_rearmed/pull/189)
Note that i am unable to cross compile the ARM code for libretro's code.