### PR TITLE
Various CDROM fixes from Duckstation and Mednafen

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -63,7 +63,7 @@ static unsigned char *pTransfer;
 #define CdlDemute      12
 #define CdlSetfilter   13
 #define CdlSetmode     14
-#define CdlGetmode     15
+#define CdlGetparam    15
 #define CdlGetlocL     16
 #define CdlGetlocP     17
 #define CdlReadT       18
@@ -83,8 +83,8 @@ static unsigned char *pTransfer;
 char *CmdName[0x100]= {
     "CdlSync",     "CdlNop",       "CdlSetloc",  "CdlPlay",
     "CdlForward",  "CdlBackward",  "CdlReadN",   "CdlStandby",
-    "CdlStop",     "CdlPause",     "CdlReset",    "CdlMute",
-    "CdlDemute",   "CdlSetfilter", "CdlSetmode", "CdlGetmode",
+    "CdlStop",     "CdlPause",     "CdlReset",   "CdlMute",
+    "CdlDemute",   "CdlSetfilter", "CdlSetmode", "CdlGetparam",
     "CdlGetlocL",  "CdlGetlocP",   "CdlReadT",   "CdlGetTN",
     "CdlGetTD",    "CdlSeekL",     "CdlSeekP",   "CdlSetclock",
     "CdlGetclock", "CdlTest",      "CdlID",      "CdlReadS",
@@ -764,13 +764,12 @@ void cdrInterrupt() {
 			no_busy_error = 1;
 			break;
 
-		case CdlGetmode:
-			SetResultSize(6);
+		case CdlGetparam:
+			SetResultSize(5);
 			cdr.Result[1] = cdr.Mode;
-			cdr.Result[2] = cdr.File;
-			cdr.Result[3] = cdr.Channel;
-			cdr.Result[4] = 0;
-			cdr.Result[5] = 0;
+			cdr.Result[2] = 0;
+			cdr.Result[3] = cdr.File;
+			cdr.Result[4] = cdr.Channel;
 			no_busy_error = 1;
 			break;
 

--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -820,7 +820,9 @@ void cdrInterrupt() {
 				cdr.Result[0] = cdr.StatP;
 				cdr.Result[1] = itob(cdr.ResultTD[2]);
 				cdr.Result[2] = itob(cdr.ResultTD[1]);
-				cdr.Result[3] = itob(cdr.ResultTD[0]);
+				/* According to Nocash's documentation, the function doesn't care about ff.
+				 * This can be seen also in Mednafen's implementation. */
+				//cdr.Result[3] = itob(cdr.ResultTD[0]);
 			}
 			break;
 

--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -48,7 +48,7 @@ cdrStruct cdr;
 static unsigned char *pTransfer;
 
 /* CD-ROM magic numbers */
-#define CdlSync        0
+#define CdlSync        0 /* nocash documentation : "Uh, actually, returns error code 40h = Invalid Command...?" */
 #define CdlNop         1
 #define CdlSetloc      2
 #define CdlPlay        3
@@ -576,10 +576,6 @@ void cdrInterrupt() {
 	cdr.Irq = 0;
 
 	switch (Irq) {
-		case CdlSync:
-			// TOOD: sometimes/always return error?
-			break;
-
 		case CdlNop:
 			if (cdr.DriveState != DRIVESTATE_LID_OPEN)
 				cdr.StatP &= ~STATUS_SHELLOPEN;
@@ -1003,6 +999,7 @@ void cdrInterrupt() {
 			start_rotating = 1;
 			break;
 
+		case CdlSync:
 		default:
 			CDR_LOG_I("Invalid command: %02x\n", Irq);
 			error = ERROR_INVALIDCMD;

--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -906,8 +906,7 @@ void cdrInterrupt() {
 			break;
 
 		case CdlGetQ:
-			// TODO?
-			CDR_LOG_I("got CdlGetQ\n");
+			no_busy_error = 1;
 			break;
 
 		case CdlReadToc:

--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -716,14 +716,28 @@ void cdrInterrupt() {
 			/*
 			Gundam Battle Assault 2: much slower (*)
 			- Fixes boot, gameplay
-
 			Hokuto no Ken 2: slower
 			- Fixes intro + subtitles
-
 			InuYasha - Feudal Fairy Tale: slower
 			- Fixes battles
 			*/
-			AddIrqQueue(CdlPause + 0x100, cdReadTime * 3);
+			/* Gameblabla - Tightening the timings (as taken from Duckstation). 
+			 * The timings from Duckstation are based upon hardware tests.
+			 * Mednafen's timing don't work for Gundam Battle Assault 2 in PAL/50hz mode,
+			 * seems to be timing sensitive as it can depend on the CPU's clock speed.
+			 * 
+			 * We will need to get around this for Bedlam/Rise 2 later...
+			 * */
+			if (cdr.DriveState != DRIVESTATE_STANDBY)
+			{
+				delay = 7000;
+			}
+			else
+			{
+				delay = (((cdr.Mode & MODE_SPEED) ? 2 : 1) * (1000000));
+				CDRMISC_INT((cdr.Mode & MODE_SPEED) ? cdReadTime / 2 : cdReadTime);
+			}
+			AddIrqQueue(CdlPause + 0x100, delay);
 			cdr.Ctrl |= 0x80;
 			break;
 


### PR DESCRIPTION
These fixes aim to address the inaccuracies of some CDROM commands and make it on par with nocash's doc and mednafen.
So far, it mostly fixes some delay issues in the Simple 1500 sound novel game as well as F1 2000 (which is notoriously time sensitive).

Notaz reviewed my PRs and he accepted all of them :
https://github.com/notaz/pcsx_rearmed/pull/209
https://github.com/notaz/pcsx_rearmed/pull/204
https://github.com/notaz/pcsx_rearmed/pull/203
https://github.com/notaz/pcsx_rearmed/pull/202
https://github.com/notaz/pcsx_rearmed/pull/201
https://github.com/notaz/pcsx_rearmed/pull/199