### PR TITLE
Always look up verify_dirty literals from offsets by neonloop

### DIFF
--- a/libpcsxcore/new_dynarec/arm/assem_arm.c
+++ b/libpcsxcore/new_dynarec/arm/assem_arm.c
@@ -241,14 +241,21 @@ static u_int get_clean_addr(int addr)
 static int verify_dirty(u_int *ptr)
 {
   #ifndef HAVE_ARMV7
+  u_int offset;
   // get from literal pool
   assert((*ptr&0xFFFF0000)==0xe59f0000);
-  u_int offset=*ptr&0xfff;
-  u_int *l_ptr=(void *)ptr+offset+8;
-  u_int source=l_ptr[0];
-  u_int copy=l_ptr[1];
-  u_int len=l_ptr[2];
-  ptr+=4;
+  offset=*ptr&0xfff;
+  u_int source=*(u_int*)((void *)ptr+offset+8);
+  ptr++;
+  assert((*ptr&0xFFFF0000)==0xe59f0000);
+  offset=*ptr&0xfff;
+  u_int copy=*(u_int*)((void *)ptr+offset+8);
+  ptr++;
+  assert((*ptr&0xFFFF0000)==0xe59f0000);
+  offset=*ptr&0xfff;
+  u_int len=*(u_int*)((void *)ptr+offset+8);
+  ptr++;
+  ptr++;
   #else
   // ARMv7 movw/movt
   assert((*ptr&0xFFF00000)==0xe3000000);
@@ -285,14 +292,21 @@ static void get_bounds(int addr,u_int *start,u_int *end)
 {
   u_int *ptr=(u_int *)addr;
   #ifndef HAVE_ARMV7
+  u_int offset;
   // get from literal pool
   assert((*ptr&0xFFFF0000)==0xe59f0000);
-  u_int offset=*ptr&0xfff;
-  u_int *l_ptr=(void *)ptr+offset+8;
-  u_int source=l_ptr[0];
-  //u_int copy=l_ptr[1];
-  u_int len=l_ptr[2];
-  ptr+=4;
+  offset=*ptr&0xfff;
+  u_int source=*(u_int*)((void *)ptr+offset+8);
+  ptr++;
+  //assert((*ptr&0xFFFF0000)==0xe59f0000);
+  //offset=*ptr&0xfff;
+  //u_int copy=*(u_int*)((void *)ptr+offset+8);
+  ptr++;
+  assert((*ptr&0xFFFF0000)==0xe59f0000);
+  offset=*ptr&0xfff;
+  u_int len=*(u_int*)((void *)ptr+offset+8);
+  ptr++;
+  ptr++;
   #else
   // ARMv7 movw/movt
   assert((*ptr&0xFFF00000)==0xe3000000);


### PR DESCRIPTION
According to neonloop himself

```
Literals are deduplicated, so there's no guarantee they will be stored
next to each other, even if they're written sequentially. verify_dirty
and get_bounds must use the offsets on each instruction, instead of
assuming values are stored sequentially.
```

According to him, this fixes a dynarec crash in FF7 on ARMv5 platforms like the F1C200S as used in the TrimUi handheld.
Given that the old3DS is ARMv6, it may also possibly fix some crashes there as well.

He granted me the permission to do a PR on his behalf. (he doesn't have a github account)
It seems that there might be a performance penalty for merging this... i wonder if there's another way.

Notaz approved the PR https://github.com/notaz/pcsx_rearmed/pull/194.

Worst case, if there are regressions, we could always revert.