### PR TITLE
Revert "libretro: Add support for ps1_rom.bin (PS3 BIOS)"

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -2651,7 +2651,6 @@ static void loadPSXBios(void)
    unsigned useHLE = 0;
 
    const char *bios[] = {
-      "PS1_ROM", "ps1_rom",
       "PSXONPSP660", "psxonpsp660",
       "SCPH101", "scph101",
       "SCPH5501", "scph5501",


### PR DESCRIPTION
This reverts commit c5c20552af08fd4158cc0e7894c1798d95f0d35b.

The PS3's PS1 bios is unfortunately nonfunctional in this core. I verified this on Linux, while @bslenul has confirmed the same on Windows and Android. With dynarec enabled, it causes an immediate segfault. Without, it causes a hard freeze. It has been nonfunctional since the commit where it was added, and unfortunately it was added as the first bios chosen as well, making the core entirely unusable if it's present at all.