### PR TITLE
Fix stutter before speech samples in Castlevania Symphony of the Night

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -1180,6 +1180,7 @@ void cdrReadInterrupt() {
 			 (cdr.Transfer[4 + 0] == cdr.File) && cdr.Channel != 255) {
 			int ret = xa_decode_sector(&cdr.Xa, cdr.Transfer+4, cdr.FirstSector);
 			if (!ret) {
+				cdr.m_locationChanged = FALSE;
 				cdrAttenuate(cdr.Xa.pcm, cdr.Xa.nsamples, cdr.Xa.stereo);
 				SPU_playADPCMchannel(&cdr.Xa);
 				cdr.FirstSector = 0;


### PR DESCRIPTION
A regression was introduced by the CDROM timings changes
https://github.com/libretro/pcsx_rearmed/commit/068a6133171b026956bbfd91e9bf4666def8823d

This was done to fix some games such as :
- Crash Team Racing's intro music cutting off too soon
- FF8 Lunar Cry FMV freeze (Disc 3)
- Worms Pinball not booting
- Xenogears (Deus fight)

However for whatever reason, this also caused ADPCM speech samples in Castlevania Symphony of the Night to stutter.

This could be caused by another underlying issue however.
Here are the commands being run by Castlevania for speech samples :
```
CD1 write: 1 (CdlNop)
CD1 write: 1 (CdlNop)
CD1 write: 9 (CdlPause)
CD1 write: e (CdlSetmode) Param[1] = { c8,}
CD1 write: 1 (CdlNop)
CD1 write: d (CdlSetfilter) Param[2] = { b, 6,}
CD1 write: 1 (CdlNop)
CD1 write: 2 (CdlSetloc) Param[3] = { 26, 1, 39,}
CD1 write: 1 (CdlNop)
CD1 write: 6 (CdlReadN)
CD1 write: 1 (CdlNop)
```
In nocash's documentation, they mention that the Setfilter command only affects ADPCM sectors. I wonder if this is related ??
In any case, while i'm aware this could be a hack, this shouldn't break any game.
This should fix https://github.com/libretro/pcsx_rearmed/issues/557.