### PR TITLE
Remove CdlGetLocP hack

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -812,9 +812,6 @@ void cdrInterrupt() {
 		case CdlGetlocP:
 			SetResultSize(8);
 			memcpy(&cdr.Result, &cdr.subq, 8);
-
-			if (!cdr.Play && !cdr.Reading)
-				cdr.Result[1] = 0; // HACK?
 			break;
 
 		case CdlReadT: // SetSession?


### PR DESCRIPTION
This was added back in 2013 or so in PCSX Rearmed.
According to some tests against Tomb Raider 1 (which is affected by the GetLocP code), it works properly without this hack.

So let's just remove it as we are now doing it properly.

Notaz also forgot the reason why he introduced the hack in the first place, see :
https://github.com/notaz/pcsx_rearmed/pull/235#issuecomment-955026232