### PR TITLE
Move CdlSetLoc to CdrInterrupt and return invalid arg error

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -570,6 +570,8 @@ void cdrInterrupt() {
 	int error = 0;
 	int delay;
 	unsigned int seekTime = 0;
+	u8 set_loc[3];
+	int i;
 
 	// Reschedule IRQ
 	if (cdr.Stat) {
@@ -603,6 +605,31 @@ void cdrInterrupt() {
 			break;
 
 		case CdlSetloc:
+			CDR_LOG("CDROM setloc command (%02X, %02X, %02X)\n", cdr.Param[0], cdr.Param[1], cdr.Param[2]);
+
+			// MM must be BCD, SS must be BCD and <0x60, FF must be BCD and <0x75
+			if (((cdr.Param[0] & 0x0F) > 0x09) || (cdr.Param[0] > 0x99) || ((cdr.Param[1] & 0x0F) > 0x09) || (cdr.Param[1] >= 0x60) || ((cdr.Param[2] & 0x0F) > 0x09) || (cdr.Param[2] >= 0x75))
+			{
+				CDR_LOG("Invalid/out of range seek to %02X:%02X:%02X\n", cdr.Param[0], cdr.Param[1], cdr.Param[2]);
+				error = ERROR_INVALIDARG;
+				goto set_error;
+			}
+			else
+			{
+				for (i = 0; i < 3; i++)
+				{
+					set_loc[i] = btoi(cdr.Param[i]);
+				}
+
+				i = msf2sec(cdr.SetSectorPlay);
+				i = abs(i - msf2sec(set_loc));
+				if (i > 16)
+					cdr.Seeked = SEEK_PENDING;
+
+				memcpy(cdr.SetSector, set_loc, 3);
+				cdr.SetSector[3] = 0;
+				cdr.SetlocPending = 1;
+			}
 			break;
 
 		do_CdlPlay:
@@ -1287,9 +1314,6 @@ unsigned char cdrRead1(void) {
 }
 
 void cdrWrite1(unsigned char rt) {
-	u8 set_loc[3];
-	int i;
-
 	CDR_LOG_IO("cdr w1: %02x\n", rt);
 
 	switch (cdr.Ctrl & 3) {
@@ -1323,32 +1347,6 @@ void cdrWrite1(unsigned char rt) {
 	AddIrqQueue(cdr.Cmd, 0x800);
 
 	switch (cdr.Cmd) {
-	case CdlSetloc:
-		CDR_LOG("CDROM setloc command (%02X, %02X, %02X)\n", cdr.Param[0], cdr.Param[1], cdr.Param[2]);
-
-		// MM must be BCD, SS must be BCD and <0x60, FF must be BCD and <0x75
-		if (((cdr.Param[0] & 0x0F) > 0x09) || (cdr.Param[0] > 0x99) || ((cdr.Param[1] & 0x0F) > 0x09) || (cdr.Param[1] >= 0x60) || ((cdr.Param[2] & 0x0F) > 0x09) || (cdr.Param[2] >= 0x75))
-		{
-			CDR_LOG("Invalid/out of range seek to %02X:%02X:%02X\n", cdr.Param[0], cdr.Param[1], cdr.Param[2]);
-		}
-		else
-		{
-			for (i = 0; i < 3; i++)
-			{
-				set_loc[i] = btoi(cdr.Param[i]);
-			}
-
-			i = msf2sec(cdr.SetSectorPlay);
-			i = abs(i - msf2sec(set_loc));
-			if (i > 16)
-				cdr.Seeked = SEEK_PENDING;
-
-			memcpy(cdr.SetSector, set_loc, 3);
-			cdr.SetSector[3] = 0;
-			cdr.SetlocPending = 1;
-		}
-		break;
-
 	case CdlReadN:
 	case CdlReadS:
 	case CdlPause:


### PR DESCRIPTION
So far, i could only find Simple 1500 Series Vol. 31 - The Sound Novel to be affected by this.
In Duckstation, this was causing extra delays without it.
However in our case, this doesn't seem to be the case and i couldn't find much find about it.