### PR TITLE
One more on odd lines for PAL HSYNC

### DIFF
--- a/libpcsxcore/psxcounters.c
+++ b/libpcsxcore/psxcounters.c
@@ -60,7 +60,7 @@ static const u32 CountToOverflow  = 0;
 static const u32 CountToTarget    = 1;
 
 static const u32 FrameRate[]      = { 60, 50 };
-static const u32 HSyncTotal[]     = { 263, 313 };
+static const u32 HSyncTotal[] = { 263, 314 }; // actually one more on odd lines for PAL
 #define VBlankStart 240
 
 #define VERBOSE_LEVEL 0


### PR DESCRIPTION
As done by Duckstation
https://github.com/stenzek/duckstation/blob/bbcf1c67d1aefd5de9cdc9c158f92bc7aaecaa63/src/core/gpu.h#L56

It was also merged upstream. This is based on nocash's documentation (and several other emulations) stating that for PAL, it should be 314 due to the additional odd line.