### PR TITLE
Fix typo for DOA pause resume fix.

### DIFF
--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -774,7 +774,7 @@ void cdrInterrupt() {
 			 * 
 			 * We will need to get around this for Bedlam/Rise 2 later...
 			 * */
-			if (cdr.DriveState != DRIVESTATE_STANDBY)
+			if (cdr.DriveState == DRIVESTATE_STANDBY)
 			{
 				delay = 7000;
 			}


### PR DESCRIPTION
Ooops, looks like i made a mistake :P

https://github.com/CometHunter92/pcsx_rearmed/commit/242b473df8b88101a013b639604b06d4418fad47

I didn't even notice this upon until someone reported it to me. It was working in redux when i merged it but i didn't do so for Rearmed... :<
