### PR TITLE
platforms: Add Miyoo target

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,6 +71,10 @@ include:
   # tvOS (AppleTV)
   - project: 'libretro-infrastructure/ci-templates'
     file: '/tvos-arm64.yml'
+
+  # OpenDingux (ARM)
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/dingux-arm32.yml'
     
   #################################### MISC ##################################
 
@@ -181,4 +185,10 @@ libretro-build-ctr:
 libretro-build-libnx-aarch64:
   extends:
     - .libretro-libnx-static-retroarch-master
+    - .core-defs
+
+# Miyoo
+libretro-build-miyoo-arm32:
+  extends:
+    - .libretro-miyoo-arm32-make-default
     - .core-defs

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -447,6 +447,18 @@ else ifneq (,$(findstring armv,$(platform)))
 	ARCH = arm
 	DYNAREC = ari64
 
+else ifeq ($(platform), miyoo)
+	TARGET := $(TARGET_NAME)_libretro.so
+	CC = /opt/miyoo/usr/bin/arm-linux-gcc
+	CXX = /opt/miyoo/usr/bin/arm-linux-g++
+	fpic := -fPIC
+	CFLAGS += -mcpu=arm926ej-s -fsingle-precision-constant
+	CFLAGS += -DGPULIB_USE_MMAP -DGPU_UNAI_USE_INT_DIV_MULTINV -D_MIYOO
+	ARCH = arm
+	BUILTIN_GPU = unai
+	DYNAREC = ari64
+	HAVE_NEON = 0
+
 # Emscripten
 else ifeq ($(platform), emscripten)
    TARGET  := $(TARGET_NAME)_libretro_$(platform).bc

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -834,7 +834,11 @@ struct retro_core_option_definition option_defs_us[] = {
          { "enabled",  NULL },
          { NULL, NULL},
       },
+#ifdef _MIYOO
+      "enabled",
+#else
       "disabled",
+#endif
    },
 #endif /* GPU UNAI Advanced Settings */
 #ifdef THREAD_RENDERING


### PR DESCRIPTION
Build for Miyoo which has the same ARM926EJ-S CPU as the Wiz/Caanoo
platforms so use similar build flags.
Enable hi-res downscaling by default for the UNAI GPU renderer to scale
to the device's 320x240 screen.