### PR TITLE
Fix SPU defaults for pre-ARMv7 CPUs

### DIFF
--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -876,7 +876,11 @@ struct retro_core_option_definition option_defs_us[] = {
          { "enabled",  NULL },
          { NULL, NULL },
       },
+#ifdef HAVE_PRE_ARMV7
+      "disabled",
+#else
       "enabled",
+#endif
    },
    {
       "pcsx_rearmed_spu_interpolation",
@@ -889,7 +893,11 @@ struct retro_core_option_definition option_defs_us[] = {
          { "off",      "disabled" },
          { NULL, NULL },
       },
+#ifdef HAVE_PRE_ARMV7
+      "off",
+#else
       "simple",
+#endif
    },
    {
       "pcsx_rearmed_pe2_fix",


### PR DESCRIPTION
Disable reverb and interpolation for pre-ARMv7 CPUs to match
emu_set_default_config(). Affects the ARMv5TEJ Miyoo and ARMv6 3DS and
Raspberry Pi 1.