### PR TITLE
Adds auto frameskip based on free audio buffer space

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -96,6 +96,18 @@ static int show_advanced_gpu_unai_settings = -1;
 static int show_other_input_settings = -1;
 static float mouse_sensitivity = 1.0f;
 
+unsigned frameskip_type                  = 0;
+unsigned frameskip_threshold             = 0;
+unsigned frameskip_counter               = 0;
+unsigned frameskip_interval              = 0;
+
+int retro_audio_buff_active              = false;
+unsigned retro_audio_buff_occupancy      = 0;
+int retro_audio_buff_underrun            = false;
+
+unsigned retro_audio_latency             = 0;
+int update_audio_latency                 = false;
+
 static unsigned previous_width = 0;
 static unsigned previous_height = 0;
 
@@ -1195,6 +1207,52 @@ static void set_retro_memmap(void)
 #endif
 }
 
+static void retro_audio_buff_status_cb(
+   bool active, unsigned occupancy, bool underrun_likely)
+{
+   retro_audio_buff_active    = active;
+   retro_audio_buff_occupancy = occupancy;
+   retro_audio_buff_underrun  = underrun_likely;
+}
+
+static void retro_set_audio_buff_status_cb(void)
+{
+   if (frameskip_type > 0)
+   {
+      struct retro_audio_buffer_status_callback buf_status_cb;
+
+      buf_status_cb.callback = retro_audio_buff_status_cb;
+      if (!environ_cb(RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK,
+            &buf_status_cb))
+      {
+         retro_audio_buff_active    = false;
+         retro_audio_buff_occupancy = 0;
+         retro_audio_buff_underrun  = false;
+         retro_audio_latency        = 0;
+      }
+      else
+      {
+         /* Frameskip is enabled - increase frontend
+          * audio latency to minimise potential
+          * buffer underruns */
+         uint32_t frame_time_usec = 1000000.0 / (is_pal_mode ? 50.0 : 60.0);
+
+         /* Set latency to 6x current frame time... */
+         retro_audio_latency = (unsigned)(6 * frame_time_usec / 1000);
+
+         /* ...then round up to nearest multiple of 32 */
+         retro_audio_latency = (retro_audio_latency + 0x1F) & ~0x1F;
+      }
+   }
+   else
+   {
+      environ_cb(RETRO_ENVIRONMENT_SET_AUDIO_BUFFER_STATUS_CALLBACK, NULL);
+      retro_audio_latency = 0;
+   }
+
+   update_audio_latency = true;
+}
+
 static void update_variables(bool in_flight);
 bool retro_load_game(const struct retro_game_info *info)
 {
@@ -1406,6 +1464,7 @@ bool retro_load_game(const struct retro_game_info *info)
    emu_on_new_cd(0);
 
    set_retro_memmap();
+   retro_set_audio_buff_status_cb();
 
    return true;
 }
@@ -1476,11 +1535,43 @@ static void update_variables(bool in_flight)
 #ifdef GPU_PEOPS
    int gpu_peops_fix = 0;
 #endif
+   unsigned prev_frameskip_type;
 
+   var.key = "pcsx_rearmed_frameskip_type";
    var.value = NULL;
-   var.key = "pcsx_rearmed_frameskip";
+
+   prev_frameskip_type = frameskip_type;
+   frameskip_type = 0;
+   pl_rearmed_cbs.frameskip = 0;
+
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-      pl_rearmed_cbs.frameskip = atoi(var.value);
+   {
+      if (strcmp(var.value, "auto") == 0)
+         frameskip_type = 1;
+      if (strcmp(var.value, "auto_threshold") == 0)
+         frameskip_type = 2;
+      if (strcmp(var.value, "fixed_interval") == 0)
+         frameskip_type = 3;
+   }
+
+   if (frameskip_type != 0)
+      pl_rearmed_cbs.frameskip = -1;
+
+   var.key = "pcsx_rearmed_frameskip_threshold";
+   var.value = NULL;
+
+   frameskip_threshold = 30;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      frameskip_threshold = strtol(var.value, NULL, 10);
+
+   var.key = "pcsx_rearmed_frameskip";
+   var.value = NULL;
+
+   frameskip_interval = 1;
+
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+      frameskip_interval = strtol(var.value, NULL, 10);
 
    var.value = NULL;
    var.key = "pcsx_rearmed_region";
@@ -2168,6 +2259,10 @@ static void update_variables(bool in_flight)
          GPU_open(&gpuDisp, "PCSX", NULL);
       }
 
+      /* Reinitialise frameskipping, if required */
+      if (((frameskip_type     != prev_frameskip_type)))
+         retro_set_audio_buff_status_cb();
+
       /* dfinput_activate(); */
    }
    else
@@ -2540,6 +2635,46 @@ void retro_run(void)
 
    print_internal_fps();
 
+   /* Check whether current frame should
+    * be skipped */
+   pl_rearmed_cbs.fskip_force = 0;
+   pl_rearmed_cbs.fskip_dirty = 0;
+   if ((frameskip_type > 0) && retro_audio_buff_active)
+   {
+      bool skip_frame;
+
+      switch (frameskip_type)
+      {
+         case 1: /* auto */
+            skip_frame = retro_audio_buff_underrun;
+            break;
+         case 2: /* threshold */
+            skip_frame = (retro_audio_buff_occupancy < frameskip_threshold);
+            break;
+         case 3: /* fixed */
+            skip_frame = true;
+            break;
+         default:
+            skip_frame = false;
+            break;
+      }
+
+      if (skip_frame && frameskip_counter < frameskip_interval)
+         pl_rearmed_cbs.fskip_force = 1;
+   }
+
+   /* If frameskip/timing settings have changed,
+    * update frontend audio latency
+    * > Can do this before or after the frameskip
+    *   check, but doing it after means we at least
+    *   retain the current frame's audio output */
+   if (update_audio_latency)
+   {
+      environ_cb(RETRO_ENVIRONMENT_SET_MINIMUM_AUDIO_LATENCY,
+            &retro_audio_latency);
+      update_audio_latency = false;
+   }
+
    input_poll_cb();
 
    update_input();
@@ -2550,6 +2685,13 @@ void retro_run(void)
 
    stop = 0;
    psxCpu->Execute();
+
+   if (pl_rearmed_cbs.fskip_dirty == 1) {
+      if (frameskip_counter < frameskip_interval)
+         frameskip_counter++;
+      else if (frameskip_counter >= frameskip_interval || !pl_rearmed_cbs.fskip_force)
+         frameskip_counter = 0;
+   }
 
    video_cb((vout_fb_dirty || !vout_can_dupe || !duping_enable) ? vout_buf_ptr : NULL,
        vout_width, vout_height, vout_width * 2);
@@ -2863,6 +3005,14 @@ void retro_deinit(void)
    /* Have to reset disks struct, otherwise
     * fnames/flabels will leak memory */
    disk_init();
+   frameskip_type             = 0;
+   frameskip_threshold        = 0;
+   frameskip_counter          = 0;
+   retro_audio_buff_active    = false;
+   retro_audio_buff_occupancy = 0;
+   retro_audio_buff_underrun  = false;
+   retro_audio_latency        = 0;
+   update_audio_latency       = false;
 }
 
 #ifdef VITA

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -51,17 +51,61 @@ extern "C" {
 
 struct retro_core_option_definition option_defs_us[] = {
    {
-      "pcsx_rearmed_frameskip",
+      "pcsx_rearmed_frameskip_type",
       "Frameskip",
-      "Choose how much frames should be skipped to improve performance at the expense of visual smoothness.",
+      "Skip frames to avoid audio buffer under-run (crackling). Improves performance at the expense of visual smoothness. 'Auto' skips frames when advised by the frontend. 'Auto (Threshold)' utilises the 'Frameskip Threshold (%)' setting. 'Fixed Interval' utilises the 'Frameskip Interval' setting.",
       {
-         { "0", NULL },
-         { "1", NULL },
-         { "2", NULL },
-         { "3", NULL },
+         { "disabled",       NULL },
+         { "auto",           "Auto" },
+         { "auto_threshold", "Auto (Threshold)" },
+         { "fixed_interval", "Fixed Interval" },
          { NULL, NULL },
       },
-      "0",
+      "disabled"
+   },
+   {
+      "pcsx_rearmed_frameskip_threshold",
+      "Frameskip Threshold (%)",
+      "When 'Frameskip' is set to 'Auto (Threshold)', specifies the audio buffer occupancy threshold (percentage) below which frames will be skipped. Higher values reduce the risk of crackling by causing frames to be dropped more frequently.",
+      {
+         { "15", NULL },
+         { "18", NULL },
+         { "21", NULL },
+         { "24", NULL },
+         { "27", NULL },
+         { "30", NULL },
+         { "33", NULL },
+         { "36", NULL },
+         { "39", NULL },
+         { "42", NULL },
+         { "45", NULL },
+         { "48", NULL },
+         { "51", NULL },
+         { "54", NULL },
+         { "57", NULL },
+         { "60", NULL },
+         { NULL, NULL },
+      },
+      "33"
+   },
+   {
+      "pcsx_rearmed_frameskip",
+      "Frameskip Interval",
+      "Specifies the maximum number of frames that can be skipped before a new frame is rendered.",
+      {
+         { "1",  NULL },
+         { "2",  NULL },
+         { "3",  NULL },
+         { "4",  NULL },
+         { "5",  NULL },
+         { "6",  NULL },
+         { "7",  NULL },
+         { "8",  NULL },
+         { "9",  NULL },
+         { "10", NULL },
+         { NULL, NULL },
+      },
+      "1"
    },
    {
       "pcsx_rearmed_bios",

--- a/frontend/plugin_lib.h
+++ b/frontend/plugin_lib.h
@@ -70,6 +70,8 @@ struct rearmed_cbs {
 	// gpu options
 	int   frameskip;
 	int   fskip_advice;
+	int   fskip_force;
+	int   fskip_dirty;
 	unsigned int *gpu_frame_count;
 	unsigned int *gpu_hcnt;
 	unsigned int flip_cnt; // increment manually if not using pl_vout_flip

--- a/plugins/gpulib/gpu.c
+++ b/plugins/gpulib/gpu.c
@@ -90,6 +90,8 @@ static noinline void update_height(void)
 
 static noinline void decide_frameskip(void)
 {
+  *gpu.frameskip.dirty = 1;
+
   if (gpu.frameskip.active)
     gpu.frameskip.cnt++;
   else {
@@ -97,7 +99,9 @@ static noinline void decide_frameskip(void)
     gpu.frameskip.frame_ready = 1;
   }
 
-  if (!gpu.frameskip.active && *gpu.frameskip.advice)
+  if (*gpu.frameskip.force)
+    gpu.frameskip.active = 1;
+  else if (!gpu.frameskip.active && *gpu.frameskip.advice)
     gpu.frameskip.active = 1;
   else if (gpu.frameskip.set > 0 && gpu.frameskip.cnt < gpu.frameskip.set)
     gpu.frameskip.active = 1;
@@ -805,6 +809,8 @@ void GPUrearmedCallbacks(const struct rearmed_cbs *cbs)
 {
   gpu.frameskip.set = cbs->frameskip;
   gpu.frameskip.advice = &cbs->fskip_advice;
+  gpu.frameskip.force = &cbs->fskip_force;
+  gpu.frameskip.dirty = &cbs->fskip_dirty;
   gpu.frameskip.active = 0;
   gpu.frameskip.frame_ready = 1;
   gpu.state.hcnt = cbs->gpu_hcnt;

--- a/plugins/gpulib/gpu.h
+++ b/plugins/gpulib/gpu.h
@@ -90,6 +90,8 @@ struct psx_gpu {
     uint32_t allow:1;
     uint32_t frame_ready:1;
     const int *advice;
+    const int *force;
+    int *dirty;
     uint32_t last_flip_frame;
     uint32_t pending_fill[3];
   } frameskip;


### PR DESCRIPTION
The change uses same style as other cores with auto frameskip. PSX doesn't always render every frame, so skipped frames that wouldn't have been rendered aren't used for frameskip limit.