### PR TITLE
frontend: Disable iTempo

### DIFF
--- a/frontend/main.c
+++ b/frontend/main.c
@@ -156,7 +156,7 @@ void emu_set_default_config(void)
 #if defined(HAVE_PRE_ARMV7) && !defined(_3DS) /* XXX GPH hack */
 	spu_config.iUseReverb = 0;
 	spu_config.iUseInterpolation = 0;
-#ifndef(_MIYOO)
+#ifndef HAVE_LIBRETRO
 	spu_config.iTempo = 1;
 #endif
 #endif


### PR DESCRIPTION
Leave iTempo set to 0 on all libbretro platforms. This fixes the build
failure for Miyoo. Also results in iTempo being 0 for Raspberry Pi 1,
which is faster than the Miyoo but slower than the new 3DS.

Fixes the CI failure for Miyoo in #636.