### PR TITLE
fixes and cleaning

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -1554,8 +1554,8 @@ static void update_variables(bool in_flight)
 #endif
    frameskip_type_t prev_frameskip_type;
 
-   var.key = "pcsx_rearmed_frameskip_type";
    var.value = NULL;
+   var.key = "pcsx_rearmed_frameskip_type";
 
    prev_frameskip_type = frameskip_type;
    frameskip_type = FRAMESKIP_NONE;
@@ -1573,22 +1573,20 @@ static void update_variables(bool in_flight)
 
    if (frameskip_type != 0)
       pl_rearmed_cbs.frameskip = -1;
-
+   
+   var.value = NULL;
    var.key = "pcsx_rearmed_frameskip_threshold";
-   var.value = NULL;
-
-   frameskip_threshold = 30;
-
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-      frameskip_threshold = strtol(var.value, NULL, 10);
+   {
+     frameskip_threshold = strtol(var.value, NULL, 10);
+   }
 
-   var.key = "pcsx_rearmed_frameskip";
    var.value = NULL;
-
-   frameskip_interval = 3;
-
+   var.key = "pcsx_rearmed_frameskip_interval";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
-      frameskip_interval = strtol(var.value, NULL, 10);
+   {
+     frameskip_interval = strtol(var.value, NULL, 10);
+   }   
 
    var.value = NULL;
    var.key = "pcsx_rearmed_region";

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -89,7 +89,7 @@ struct retro_core_option_definition option_defs_us[] = {
       "33"
    },
    {
-      "pcsx_rearmed_frameskip",
+      "pcsx_rearmed_frameskip_interval",
       "Frameskip Interval",
       "Specifies the maximum number of frames that can be skipped before a new frame is rendered.",
       {
@@ -105,7 +105,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "10", NULL },
          { NULL, NULL },
       },
-      "3"
+      "1"
    },
    {
       "pcsx_rearmed_bios",

--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -105,7 +105,7 @@ struct retro_core_option_definition option_defs_us[] = {
          { "10", NULL },
          { NULL, NULL },
       },
-      "1"
+      "3"
    },
    {
       "pcsx_rearmed_bios",


### PR DESCRIPTION
fixes core options getting crazy if coming from a previous core version;
plus a little bit of cleaning and <s>reverting to "frameskip interval = 1" as default, as a value of "3" is too high<s>