### PR TITLE
lightrec: Fix save states

### DIFF
--- a/libpcsxcore/lightrec/plugin.c
+++ b/libpcsxcore/lightrec/plugin.c
@@ -554,6 +554,28 @@ static void lightrec_plugin_reset(void)
 	booting = true;
 }
 
+void lightrec_plugin_prepare_load_state(void)
+{
+	struct lightrec_registers *regs;
+
+	regs = lightrec_get_registers(lightrec_state);
+	memcpy(regs->cp2d, &psxRegs.CP2, sizeof(regs->cp2d) + sizeof(regs->cp2c));
+	memcpy(regs->cp0, &psxRegs.CP0, sizeof(regs->cp0));
+	memcpy(regs->gpr, &psxRegs.GPR, sizeof(regs->gpr));
+
+	lightrec_invalidate_all(lightrec_state);
+}
+
+void lightrec_plugin_prepare_save_state(void)
+{
+	struct lightrec_registers *regs;
+
+	regs = lightrec_get_registers(lightrec_state);
+	memcpy(&psxRegs.CP2, regs->cp2d, sizeof(regs->cp2d) + sizeof(regs->cp2c));
+	memcpy(&psxRegs.CP0, regs->cp0, sizeof(regs->cp0));
+	memcpy(&psxRegs.GPR, regs->gpr, sizeof(regs->gpr));
+}
+
 R3000Acpu psxRec =
 {
 	lightrec_plugin_init,

--- a/libpcsxcore/r3000a.h
+++ b/libpcsxcore/r3000a.h
@@ -204,6 +204,9 @@ extern psxRegisters psxRegs;
 extern u32 event_cycles[PSXINT_COUNT];
 extern u32 next_interupt;
 
+void lightrec_plugin_prepare_save_state(void);
+void lightrec_plugin_prepare_load_state(void);
+
 void new_dyna_before_save(void);
 void new_dyna_after_save(void);
 void new_dyna_freeze(void *f, int mode);


### PR DESCRIPTION
To create save states the psxRegs variable must be up-to-date. Therefore
we need to store back all the registers in Lightrec's cache into psxRegs
before saving, and reload them into Lightrec's cache after loading a
save state.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>