### PR TITLE
Update lightrec 20220427

### DIFF
--- a/deps/lightning/.gitrepo
+++ b/deps/lightning/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/pcercuei/gnu_lightning.git
 	branch = pcsx_rearmed
-	commit = ac905ceb09ce479623377733c4b463f1aa3eb99e
-	parent = b74a54b1ac0fa605f56411704fb902d7cf17c71a
+	commit = 6f101bf8eccef737d60bf7e6ba85558db49e7908
+	parent = 02dbc8694f303728f19734328166a1c6dfef289c
 	method = merge
 	cmdver = 0.4.3

--- a/deps/lightning/check/Makefile.am
+++ b/deps/lightning/check/Makefile.am
@@ -82,6 +82,7 @@ EXTRA_DIST =				\
 	alu_rsh.tst	alu_rsh.ok	\
 	alu_com.tst	alu_com.ok	\
 	alu_neg.tst	alu_neg.ok	\
+	movzr.tst	movzr.ok	\
 	fop_abs.tst	fop_abs.ok	\
 	fop_sqrt.tst	fop_sqrt.ok	\
 	varargs.tst	varargs.ok	\
@@ -123,6 +124,7 @@ base_TESTS =				\
 	alu_and alu_or alu_xor		\
 	alu_lsh alu_rsh			\
 	alu_com alu_neg			\
+	movzr				\
 	fop_abs fop_sqrt		\
 	varargs stack			\
 	clobber carry call		\
@@ -151,6 +153,7 @@ x87_TESTS =					\
 	alu_and.x87 alu_or.x87 alu_xor.x87	\
 	alu_lsh.x87 alu_rsh.x87			\
 	alu_com.x87 alu_neg.x87			\
+	movzr.x87				\
 	fop_abs.x87 fop_sqrt.x87		\
 	varargs.x87 stack.x87			\
 	clobber.x87 carry.x87 call.x87		\
@@ -174,6 +177,7 @@ x87_nodata_TESTS =							\
 	alu_and.x87.nodata alu_or.x87.nodata alu_xor.x87.nodata		\
 	alu_lsh.x87.nodata alu_rsh.x87.nodata				\
 	alu_com.x87.nodata alu_neg.x87.nodata				\
+	movzr.x87.nodata						\
 	fop_abs.x87.nodata fop_sqrt.x87.nodata				\
 	varargs.x87.nodata stack.x87.nodata				\
 	clobber.x87.nodata carry.x87.nodata call.x87.nodata		\
@@ -199,6 +203,7 @@ arm_TESTS =					\
 	alu_and.arm alu_or.arm alu_xor.arm	\
 	alu_lsh.arm alu_rsh.arm			\
 	alu_com.arm alu_neg.arm			\
+	movzr.arm				\
 	fop_abs.arm fop_sqrt.arm		\
 	varargs.arm stack.arm			\
 	clobber.arm carry.arm call.arm		\
@@ -224,6 +229,7 @@ swf_TESTS =					\
 	alu_and.swf alu_or.swf alu_xor.swf	\
 	alu_lsh.swf alu_rsh.swf			\
 	alu_com.swf alu_neg.swf			\
+	movzr.swf				\
 	fop_abs.swf fop_sqrt.swf		\
 	varargs.swf stack.swf			\
 	clobber.swf carry.swf call.swf		\
@@ -247,6 +253,7 @@ arm_swf_TESTS =							\
 	alu_and.arm.swf alu_or.arm.swf alu_xor.arm.swf		\
 	alu_lsh.arm.swf alu_rsh.arm.swf				\
 	alu_com.arm.swf alu_neg.arm.swf				\
+	movzr.arm.swf						\
 	fop_abs.arm.swf fop_sqrt.arm.swf			\
 	varargs.arm.swf stack.arm.swf				\
 	clobber.arm.swf carry.arm.swf call.arm.swf		\
@@ -271,6 +278,7 @@ arm4_swf_TESTS =						\
 	alu_and.arm4.swf alu_or.arm4.swf alu_xor.arm4.swf	\
 	alu_lsh.arm4.swf alu_rsh.arm4.swf			\
 	alu_com.arm4.swf alu_neg.arm4.swf			\
+	movzr.arm4.swf						\
 	fop_abs.arm4.swf fop_sqrt.arm4.swf			\
 	varargs.arm4.swf stack.arm4.swf				\
 	clobber.arm4.swf carry.arm4.swf call.arm4.swf		\
@@ -298,6 +306,7 @@ nodata_TESTS =						\
 	alu_and.nodata alu_or.nodata alu_xor.nodata	\
 	alu_lsh.nodata alu_rsh.nodata			\
 	alu_com.nodata alu_neg.nodata			\
+	movzr.nodata					\
 	fop_abs.nodata fop_sqrt.nodata			\
 	varargs.nodata stack.nodata			\
 	clobber.nodata carry.nodata call.nodata		\

--- a/deps/lightning/check/lightning.c
+++ b/deps/lightning/check/lightning.c
@@ -327,6 +327,7 @@ static void htonr_ui(void);	static void ntohr_ui(void);
 static void htonr_ul(void);	static void ntohr_ul(void);
 #endif
 static void htonr(void);	static void ntohr(void);
+static void movnr(void);	static void movzr(void);
 static void ldr_c(void);	static void ldi_c(void);
 static void ldr_uc(void);	static void ldi_uc(void);
 static void ldr_s(void);	static void ldi_s(void);
@@ -641,6 +642,7 @@ static instr_t		  instr_vector[] = {
     entry(htonr_ul),	entry(ntohr_ul),
 #endif
     entry(htonr),	entry(ntohr),
+    entry(movnr),	entry(movzr),
     entry(ldr_c),	entry(ldi_c),
     entry(ldr_uc), 	entry(ldi_uc),
     entry(ldr_s),	entry(ldi_s),
@@ -1489,6 +1491,7 @@ entry_ir_ir(htonr_ui)		entry_ir_ir(ntohr_ui)
 entry_ir_ir(htonr_ul)		entry_ir_ir(ntohr_ul)
 #endif
 entry_ir_ir(htonr)		entry_ir_ir(ntohr)
+entry_ir_ir_ir(movnr)		entry_ir_ir_ir(movzr)
 entry_ir_ir(ldr_c)		entry_ir_pm(ldi_c)
 entry_ir_ir(ldr_uc)		entry_ir_pm(ldi_uc)
 entry_ir_ir(ldr_s)		entry_ir_pm(ldi_s)

--- a/deps/lightning/lib/jit_aarch64-cpu.c
+++ b/deps/lightning/lib/jit_aarch64-cpu.c
@@ -290,6 +290,7 @@ typedef union {
 #  define A64_CBNZ			0x35000000
 #  define A64_B_C			0x54000000
 #  define A64_CSINC			0x1a800400
+#  define A64_CSSEL			0x1a800000
 #  define A64_REV			0xdac00c00
 #  define A64_UDIV			0x1ac00800
 #  define A64_SDIV			0x1ac00c00
@@ -461,6 +462,7 @@ typedef union {
 #  define LDPI_PRE(Rt,Rt2,Rn,Simm7)	oxxx7(A64_LDP_PRE|XS,Rt,Rt2,Rn,Simm7)
 #  define STPI_POS(Rt,Rt2,Rn,Simm7)	oxxx7(A64_STP_POS|XS,Rt,Rt2,Rn,Simm7)
 #  define CSET(Rd,Cc)			CSINC(Rd,XZR_REGNO,XZR_REGNO,Cc)
+#  define CSEL(Rd,Rn,Rm,Cc)		oxxxc(A64_CSSEL|XS,Rd,Rn,Rm,Cc)
 #  define B(Simm26)			o26(A64_B,Simm26)
 #  define BL(Simm26)			o26(A64_BL,Simm26)
 #  define BR(Rn)			o_x_(A64_BR,Rn)
@@ -572,6 +574,10 @@ static void _rshi(jit_state_t*,jit_int32_t,jit_int32_t,jit_word_t);
 #  define rshr_u(r0,r1,r2)		LSR(r0,r1,r2)
 #  define rshi_u(r0,r1,i0)		_rshi_u(_jit,r0,r1,i0)
 static void _rshi_u(jit_state_t*,jit_int32_t,jit_int32_t,jit_word_t);
+#  define movnr(r0,r1,r2)		_movnr(_jit,r0,r1,r2)
+static void _movnr(jit_state_t*,jit_int32_t,jit_int32_t,jit_int32_t);
+#  define movzr(r0,r1,r2)		_movzr(_jit,r0,r1,r2)
+static void _movzr(jit_state_t*,jit_int32_t,jit_int32_t,jit_int32_t);
 #  define negr(r0,r1)			NEG(r0,r1)
 #  define comr(r0,r1)			MVN(r0,r1)
 #  define andr(r0,r1,r2)		AND(r0,r1,r2)
@@ -1373,6 +1379,20 @@ _rshi_u(jit_state_t *_jit, jit_int32_t r0, jit_int32_t r1, jit_word_t i0)
 	assert(i0 > 0 && i0 < 64);
 	LSRI(r0, r1, i0);
     }
+}
+
+static void
+_movnr(jit_state_t *_jit, jit_int32_t r0, jit_int32_t r1, jit_int32_t r2)
+{
+	CMPI(r2, 0);
+	CSEL(r0, r0, r1, CC_NE);
+}
+
+static void
+_movzr(jit_state_t *_jit, jit_int32_t r0, jit_int32_t r1, jit_int32_t r2)
+{
+	CMPI(r2, 0);
+	CSEL(r0, r0, r1, CC_EQ);
 }
 
 static void

--- a/deps/lightning/lib/jit_aarch64-sz.c
+++ b/deps/lightning/lib/jit_aarch64-sz.c
@@ -399,4 +399,6 @@
     0,	/* movi_d_ww */
     0,	/* movr_d_w */
     0,	/* movi_d_w */
+    8,	/* movnr */
+    8,	/* movzr */
 #endif /* __WORDSIZE */

--- a/deps/lightning/lib/jit_aarch64.c
+++ b/deps/lightning/lib/jit_aarch64.c
@@ -1135,6 +1135,8 @@ _emit_code(jit_state_t *_jit)
 		case_rr(ext, _i);
 		case_rr(ext, _ui);
 		case_rr(mov,);
+		case_rrr(movn,);
+		case_rrr(movz,);
 	    case jit_code_movi:
 		if (node->flag & jit_flag_node) {
 		    temp = node->v.n;

--- a/deps/lightning/lib/jit_arm-cpu.c
+++ b/deps/lightning/lib/jit_arm-cpu.c
@@ -843,6 +843,10 @@ static void _movr(jit_state_t*,jit_int32_t,jit_int32_t);
 static void _movi(jit_state_t*,jit_int32_t,jit_word_t);
 #  define movi_p(r0,i0)			_movi_p(_jit,r0,i0)
 static jit_word_t _movi_p(jit_state_t*,jit_int32_t,jit_word_t);
+#  define movnr(r0,r1,r2)		_movnr(_jit,r0,r1,r2)
+static void _movnr(jit_state_t*,jit_int32_t,jit_int32_t,jit_int32_t);
+#  define movzr(r0,r1,r2)		_movzr(_jit,r0,r1,r2)
+static void _movzr(jit_state_t*,jit_int32_t,jit_int32_t,jit_int32_t);
 #  define comr(r0,r1)			_comr(_jit,r0,r1)
 static void _comr(jit_state_t*,jit_int32_t,jit_int32_t);
 #  define negr(r0,r1)			_negr(_jit,r0,r1)
@@ -1580,6 +1584,35 @@ _movi_p(jit_state_t *_jit, jit_int32_t r0, jit_word_t i0)
     else
 	load_const(1, r0, 0);
     return (w);
+}
+
+static void
+_movznr(jit_state_t *_jit, int ct, jit_int32_t r0,
+        jit_int32_t r1, jit_int32_t r2)
+{
+    if (jit_thumb_p()) {
+        if (r2 < 7)
+            T1_CMPI(r2, 0);
+        else
+            T2_CMPI(r2, 0);
+        IT(ct);
+        T1_MOV(r0, r1);
+    } else {
+        CMPI(r2, 0);
+        CC_MOV(ct, r0, r1);
+    }
+}
+
+static void
+_movnr(jit_state_t *_jit, jit_int32_t r0, jit_int32_t r1, jit_int32_t r2)
+{
+    _movznr(_jit, ARM_CC_NE, r0, r1, r2);
+}
+
+static void
+_movzr(jit_state_t *_jit, jit_int32_t r0, jit_int32_t r1, jit_int32_t r2)
+{
+    _movznr(_jit, ARM_CC_EQ, r0, r1, r2);
 }
 
 static void

--- a/deps/lightning/lib/jit_arm-sz.c
+++ b/deps/lightning/lib/jit_arm-sz.c
@@ -804,5 +804,7 @@
     12,	/* movi_d_ww */
     0,	/* movr_d_w */
     0,	/* movi_d_w */
+    8,	/* movnr */
+    8,	/* movzr */
 #endif /* __ARM_PCS_VFP */
 #endif /* __WORDSIZE */

--- a/deps/lightning/lib/jit_arm.c
+++ b/deps/lightning/lib/jit_arm.c
@@ -1503,6 +1503,8 @@ _emit_code(jit_state_t *_jit)
 		case_rr(ext, _s);
 		case_rr(ext, _us);
 		case_rr(mov,);
+		case_rrr(movn,);
+		case_rrr(movz,);
 	    case jit_code_movi:
 		if (node->flag & jit_flag_node) {
 		    temp = node->v.n;

--- a/deps/lightning/lib/jit_ppc-cpu.c
+++ b/deps/lightning/lib/jit_ppc-cpu.c
@@ -505,6 +505,10 @@ static void _nop(jit_state_t*,jit_int32_t);
 static void _movr(jit_state_t*,jit_int32_t,jit_int32_t);
 #  define movi(r0,i0)			_movi(_jit,r0,i0)
 static void _movi(jit_state_t*,jit_int32_t,jit_word_t);
+#  define movnr(r0,r1,r2)		_movnr(_jit,r0,r1,r2)
+static void _movnr(jit_state_t*,jit_int32_t,jit_int32_t,jit_int32_t);
+#  define movzr(r0,r1,r2)		_movzr(_jit,r0,r1,r2)
+static void _movzr(jit_state_t*,jit_int32_t,jit_int32_t,jit_int32_t);
 #  define movi_p(r0,i0)			_movi_p(_jit,r0,i0)
 static jit_word_t _movi_p(jit_state_t*,jit_int32_t,jit_word_t);
 #  define negr(r0,r1)			NEG(r0,r1)
@@ -1118,6 +1122,22 @@ _movi(jit_state_t *_jit, jit_int32_t r0, jit_word_t i0)
 	if (i0 & 0xffff)
 	    ORI(r0, r0, (jit_uint16_t)i0);
     }
+}
+
+static void
+_movnr(jit_state_t *_jit, jit_int32_t r0, jit_int32_t r1, jit_int32_t r2)
+{
+    CMPWI(r2, 0);
+    BEQ(8);
+    MR(r0, r1);
+}
+
+static void
+_movzr(jit_state_t *_jit, jit_int32_t r0, jit_int32_t r1, jit_int32_t r2)
+{
+    CMPWI(r2, 0);
+    BNE(8);
+    MR(r0, r1);
 }
 
 static jit_word_t

--- a/deps/lightning/lib/jit_ppc-sz.c
+++ b/deps/lightning/lib/jit_ppc-sz.c
@@ -401,6 +401,8 @@
     0,	/* movi_d_ww */
     0,	/* movr_d_w */
     0,	/* movi_d_w */
+    12,  /* movnr */
+    12,  /* movzr */
 #endif /* _CALL_SYV */
 #endif /* __BYTE_ORDER */
 #endif /* __powerpc__ */
@@ -809,6 +811,8 @@
     0,	/* movi_d_ww */
     0,	/* movr_d_w */
     0,	/* movi_d_w */
+    12,  /* movnr */
+    12,  /* movzr */
 #endif /* _CALL_AIX */
 #endif /* __BYTEORDER */
 #endif /* __powerpc__ */
@@ -1216,6 +1220,8 @@
     0,	/* movi_d_ww */
     0,	/* movr_d_w */
     0,	/* movi_d_w */
+    12,  /* movnr */
+    12,  /* movzr */
 #endif /* __BYTEORDER */
 #endif /* __powerpc__ */
 #endif /* __WORDSIZE */
@@ -1622,6 +1628,8 @@
     0,	/* movi_d_ww */
     0,	/* movr_d_w */
     0,	/* movi_d_w */
+    12,  /* movnr */
+    12,  /* movzr */
 #endif /* __BYTE_ORDER */
 #endif /* __powerpc__ */
 #endif /* __WORDSIZE */

--- a/deps/lightning/lib/jit_ppc.c
+++ b/deps/lightning/lib/jit_ppc.c
@@ -1358,6 +1358,8 @@ _emit_code(jit_state_t *_jit)
 #  endif
 		case_rr(neg,);
 		case_rr(com,);
+		case_rrr(movn,);
+		case_rrr(movz,);
 		case_rr(mov,);
 	    case jit_code_movi:
 		if (node->flag & jit_flag_node) {

--- a/libpcsxcore/misc.c
+++ b/libpcsxcore/misc.c
@@ -624,7 +624,7 @@ int SaveState(const char *file) {
 
 	new_dyna_before_save();
 
-	if (drc_is_lightrec())
+	if (drc_is_lightrec() && Config.Cpu != CPU_INTERPRETER)
 		lightrec_plugin_prepare_save_state();
 
 	SaveFuncs.write(f, (void *)PcsxHeader, 32);


### PR DESCRIPTION
- Sync GNU Lightning to the latest version from my repository. It adds implementations of conditional opcodes on ARM (+thumb2), Aarch64 and PowerPC.
- Add a fix to the previous "fix savestates" PR. Synchronizing Lightrec's register cache into PCSX' psxRegs variable must
be done only if using Lightrec, not when using PCSX' interpreter.