### PR TITLE
Update core options to v2 format

### DIFF
--- a/frontend/libretro_core_options.h
+++ b/frontend/libretro_core_options.h
@@ -13,9 +13,10 @@
 
 /*
  ********************************
- * VERSION: 1.3
+ * VERSION: 2.0
  ********************************
  *
+ * - 2.0: Add support for core options v2 interface
  * - 1.3: Move translations to libretro_core_options_intl.h
  *        - libretro_core_options_intl.h includes BOM and utf-8
  *          fix for MSVC 2010-2013
@@ -49,91 +50,114 @@ extern "C" {
  *   frontend language definition
  */
 
-struct retro_core_option_definition option_defs_us[] = {
+struct retro_core_option_v2_category option_cats_us[] = {
    {
-      "pcsx_rearmed_frameskip_type",
-      "Frameskip",
-      "Skip frames to avoid audio buffer under-run (crackling). Improves performance at the expense of visual smoothness. 'Auto' skips frames when advised by the frontend. 'Auto (Threshold)' utilises the 'Frameskip Threshold (%)' setting. 'Fixed Interval' utilises the 'Frameskip Interval' setting.",
-      {
-         { "disabled",       NULL },
-         { "auto",           "Auto" },
-         { "auto_threshold", "Auto (Threshold)" },
-         { "fixed_interval", "Fixed Interval" },
-         { NULL, NULL },
-      },
-      "disabled"
+      "system",
+      "System",
+      "Configure base hardware parameters: region, BIOS selection, memory cards, etc."
    },
    {
-      "pcsx_rearmed_frameskip_threshold",
-      "Frameskip Threshold (%)",
-      "When 'Frameskip' is set to 'Auto (Threshold)', specifies the audio buffer occupancy threshold (percentage) below which frames will be skipped. Higher values reduce the risk of crackling by causing frames to be dropped more frequently.",
-      {
-         { "15", NULL },
-         { "18", NULL },
-         { "21", NULL },
-         { "24", NULL },
-         { "27", NULL },
-         { "30", NULL },
-         { "33", NULL },
-         { "36", NULL },
-         { "39", NULL },
-         { "42", NULL },
-         { "45", NULL },
-         { "48", NULL },
-         { "51", NULL },
-         { "54", NULL },
-         { "57", NULL },
-         { "60", NULL },
-         { NULL, NULL },
-      },
-      "33"
+      "video",
+      "Video",
+      "Configure base display parameters."
+   },
+#ifdef GPU_NEON
+   {
+      "gpu_neon",
+      "GPU Plugin",
+      "Configure low-level settings of the NEON GPU plugin."
+   },
+#endif
+#ifdef GPU_PEOPS
+   {
+      "gpu_peops",
+      "GPU Plugin (Advanced)",
+      "Configure low-level settings of the P.E.Op.S. GPU plugin."
+   },
+#endif
+#ifdef GPU_UNAI
+   {
+      "gpu_unai",
+      "GPU Plugin (Advanced)",
+      "Configure low-level settings of the UNAI GPU plugin."
+   },
+#endif
+   {
+      "audio",
+      "Audio",
+      "Configure sound emulation: reverb, interpolation, CD audio decoding."
    },
    {
-      "pcsx_rearmed_frameskip_interval",
-      "Frameskip Interval",
-      "Specifies the maximum number of frames that can be skipped before a new frame is rendered.",
-      {
-         { "1",  NULL },
-         { "2",  NULL },
-         { "3",  NULL },
-         { "4",  NULL },
-         { "5",  NULL },
-         { "6",  NULL },
-         { "7",  NULL },
-         { "8",  NULL },
-         { "9",  NULL },
-         { "10", NULL },
-         { NULL, NULL },
-      },
-      "3"
+      "input",
+      "Input",
+      "Configure input devices: analog response, haptic feedback, Multitaps, light guns, etc."
    },
    {
-      "pcsx_rearmed_bios",
-      "Use BIOS",
-      "Allows you to use real bios file (if available) or emulated bios (HLE). Its recommended to use official bios file for better compatibility.",
-      {
-         { "auto", "auto" },
-         { "HLE",  "hle" },
-         { NULL, NULL },
-      },
-      "auto",
+      "compat_hack",
+      "Compatibility Fixes",
+      "Configure settings/workarounds required for correct operation of specific games."
    },
+#if !defined(DRC_DISABLE) && !defined(LIGHTREC)
+   {
+      "speed_hack",
+      "Speed Hacks (Advanced)",
+      "Configure hacks that may improve performance at the expense of decreased accuracy/stability."
+   },
+#endif
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_us[] = {
    {
       "pcsx_rearmed_region",
       "Region",
-      "Choose what region the system is from. 60 Hz for NTSC, 50 Hz for PAL.",
+      NULL,
+      "Specify which region the system is from. 'NTSC' is 60 Hz while 'PAL' is 50 Hz. 'Auto' will detect the region of the currently loaded content. Games may run faster or slower than normal if the incorrect region is selected.",
+      NULL,
+      "system",
       {
-         { "auto", "auto" },
-         { "NTSC", "ntsc" },
-         { "PAL",  "pal" },
+         { "auto", "Auto" },
+         { "NTSC", NULL },
+         { "PAL",  NULL },
          { NULL, NULL },
       },
       "auto",
+   },
+   {
+      "pcsx_rearmed_bios",
+      "BIOS Selection",
+      NULL,
+      "Specify which BIOS to use. 'Auto' will attempt to load a real bios file from the frontend 'system' directory, falling back to high level emulation if unavailable. 'HLE' forces high level BIOS emulation. It is recommended to use an official bios file for better compatibility.",
+      NULL,
+      "system",
+      {
+         { "auto", "Auto" },
+         { "HLE",  NULL },
+         { NULL, NULL },
+      },
+      "auto",
+   },
+   {
+      "pcsx_rearmed_show_bios_bootlogo",
+      "Show BIOS Boot Logo",
+      NULL,
+      "When using an official BIOS file, specify whether to show the PlayStation logo upon starting or resetting content. Warning: Enabling the boot logo may reduce game compatibility.",
+      NULL,
+      "system",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
    },
    {
       "pcsx_rearmed_memcard2",
       "Enable Second Memory Card (Shared)",
-      "Enabled the memory card slot 2. This memory card is shared amongst all games.",
+      NULL,
+      "Emulate a second memory card in slot 2. This will be shared by all games.",
+      NULL,
+      "system",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -141,393 +165,31 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled",
    },
+#ifndef _WIN32
    {
-      "pcsx_rearmed_show_other_input_settings",
-      "Show other input settings",
-      "Shows or hides other inputs settings like multitaps, player 3-8 ports, analog fine-tunings, etc.",
+      "pcsx_rearmed_async_cd",
+      "CD Access Method (Restart)",
+      NULL,
+      "Select method used to read data from content disk images. 'Synchronous' mimics original hardware. 'Asynchronous' can reduce stuttering on devices with slow storage. 'Pre-Cache (CHD)' loads disk image into memory for faster access (CHD files only).",
+      NULL,
+      "system",
       {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
+         { "sync",     "Synchronous" },
+         { "async",    "Asynchronous" },
+         { "precache", "Pre-Cache (CHD)" },
+         { NULL, NULL},
       },
-      "disabled",
+      "sync",
    },
-   {
-      "pcsx_rearmed_input_sensitivity",
-      "Emulated Mouse Sensitivity",
-      "Adjust responsiveness when using mouse controller (Default 1.0).",
-      {
-         { "0.05", NULL },
-         { "0.10", NULL },
-         { "0.15", NULL },
-         { "0.20", NULL },
-         { "0.25", NULL },
-         { "0.30", NULL },
-         { "0.35", NULL },
-         { "0.40", NULL },
-         { "0.45", NULL },
-         { "0.50", NULL },
-         { "0.55", NULL },
-         { "0.60", NULL },
-         { "0.65", NULL },
-         { "0.70", NULL },
-         { "0.75", NULL },
-         { "0.80", NULL },
-         { "0.85", NULL },
-         { "0.90", NULL },
-         { "0.95", NULL },
-         { "1.00", NULL },
-         { "1.05", NULL },
-         { "1.10", NULL },
-         { "1.15", NULL },
-         { "1.20", NULL },
-         { "1.25", NULL },
-         { "1.30", NULL },
-         { "1.35", NULL },
-         { "1.40", NULL },
-         { "1.45", NULL },
-         { "1.50", NULL },
-         { "1.55", NULL },
-         { "1.60", NULL },
-         { "1.65", NULL },
-         { "1.70", NULL },
-         { "1.75", NULL },
-         { "1.80", NULL },
-         { "1.85", NULL },
-         { "1.90", NULL },
-         { "1.95", NULL },
-         { "2.00", NULL },
-      },
-      "1.00",
-   },
-   {
-      "pcsx_rearmed_multitap",
-      "Multitap Mode (Restart)",
-      "Sets the playstation multitap peripheral to either controller port 1 or controller port 2 to support of upto 5 players simultaneously, or on both for upto 8 players simultaneously. Option depends on games that has support for multitap feature. Leave option on disabled if not such compatible games to avoid any input-related problems.",
-      {
-         { "disabled",      NULL },
-         { "port 1",        NULL },
-         { "port 2",        NULL },
-         { "ports 1 and 2", NULL },
-         { NULL, NULL },
-      },
-      "disabled",
-   },
-   {
-      "pcsx_rearmed_negcon_deadzone",
-      "NegCon Twist Deadzone (Percent)",
-      "Sets the deadzone of the RetroPad left analog stick when simulating the 'twist' action of emulated neGcon Controllers. Used to eliminate drift/unwanted input.",
-      {
-         { "0",  NULL },
-         { "5",  NULL },
-         { "10", NULL },
-         { "15", NULL },
-         { "20", NULL },
-         { "25", NULL },
-         { "30", NULL },
-         { NULL, NULL },
-      },
-      "0",
-   },
-   {
-      "pcsx_rearmed_negcon_response",
-      "NegCon Twist Response",
-      "Specifies the analog response when using a RetroPad left analog stick to simulate the 'twist' action of emulated neGcon Controllers.",
-      {
-         { "linear",    NULL },
-         { "quadratic", NULL },
-         { "cubic",     NULL },
-         { NULL, NULL },
-      },
-      "linear",
-   },
-   {
-      "pcsx_rearmed_analog_axis_modifier",
-      "Analog axis bounds.",
-      "Range bounds for analog axis. Square bounds help controllers with highly circular ranges that are unable to fully saturate the x and y axis at 45degree deflections.",
-      {
-         { "circle", NULL },
-         { "square", NULL },
-         { NULL, NULL },
-      },
-      "circle",
-   },
-   {
-      "pcsx_rearmed_vibration",
-      "Enable Vibration",
-      "Enables vibration feedback for controllers that supports vibration features.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "enabled",
-   },
-   {
-      "pcsx_rearmed_gunconadjustx",
-      "Guncon Adjust X",
-      "When using Guncon mode, you can override aim in emulator if shots misaligned, this applies an increment on the x axis.",
-      {
-         { "0", NULL },
-         { "-25", NULL },
-         { "-24", NULL },
-         { "-23", NULL },
-         { "-22", NULL },
-         { "-21", NULL },
-         { "-20", NULL },
-         { "-19", NULL },
-         { "-18", NULL },
-         { "-17", NULL },
-         { "-16", NULL },
-         { "-15", NULL },
-         { "-14", NULL },
-         { "-13", NULL },
-         { "-12", NULL },
-         { "-11", NULL },
-         { "-10", NULL },
-         { "-09", NULL },
-         { "-08", NULL },
-         { "-07", NULL },
-         { "-06", NULL },
-         { "-05", NULL },
-         { "-04", NULL },
-         { "-03", NULL },
-         { "-02", NULL },
-         { "-01", NULL },
-         { "00", NULL },
-         { "01", NULL },
-         { "02", NULL },
-         { "03", NULL },
-         { "04", NULL },
-         { "05", NULL },
-         { "06", NULL },
-         { "07", NULL },
-         { "08", NULL },
-         { "09", NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { "17", NULL },
-         { "18", NULL },
-         { "19", NULL },
-         { "20", NULL },
-         { "21", NULL },
-         { "22", NULL },
-         { "23", NULL },
-         { "24", NULL },
-         { "25", NULL },
-         { NULL, NULL },
-      },
-      "0",
-   },
-   {
-      "pcsx_rearmed_gunconadjusty",
-      "Guncon Adjust Y",
-      "When using Guncon mode, you can override aim in emulator if shots misaligned, this applies an increment on the y axis.",
-      {
-         { "0", NULL },
-         { "-25", NULL },
-         { "-24", NULL },
-         { "-23", NULL },
-         { "-22", NULL },
-         { "-21", NULL },
-         { "-20", NULL },
-         { "-19", NULL },
-         { "-18", NULL },
-         { "-17", NULL },
-         { "-16", NULL },
-         { "-15", NULL },
-         { "-14", NULL },
-         { "-13", NULL },
-         { "-12", NULL },
-         { "-11", NULL },
-         { "-10", NULL },
-         { "-09", NULL },
-         { "-08", NULL },
-         { "-07", NULL },
-         { "-06", NULL },
-         { "-05", NULL },
-         { "-04", NULL },
-         { "-03", NULL },
-         { "-02", NULL },
-         { "-01", NULL },
-         { "00", NULL },
-         { "01", NULL },
-         { "02", NULL },
-         { "03", NULL },
-         { "04", NULL },
-         { "05", NULL },
-         { "06", NULL },
-         { "07", NULL },
-         { "08", NULL },
-         { "09", NULL },
-         { "10", NULL },
-         { "11", NULL },
-         { "12", NULL },
-         { "13", NULL },
-         { "14", NULL },
-         { "15", NULL },
-         { "16", NULL },
-         { "17", NULL },
-         { "18", NULL },
-         { "19", NULL },
-         { "20", NULL },
-         { "21", NULL },
-         { "22", NULL },
-         { "23", NULL },
-         { "24", NULL },
-         { "25", NULL },
-         { NULL, NULL },
-      },
-      "0",
-   },
-   {
-      "pcsx_rearmed_gunconadjustratiox",
-      "Guncon Adjust Ratio X",
-      "When using Guncon mode, you can override aim in emulator if shots misaligned, this applies a ratio on the x axis.",
-      {
-         { "1", NULL },
-         { "0.75", NULL },
-         { "0.76", NULL },
-         { "0.77", NULL },
-         { "0.78", NULL },
-         { "0.79", NULL },
-         { "0.80", NULL },
-         { "0.81", NULL },
-         { "0.82", NULL },
-         { "0.83", NULL },
-         { "0.84", NULL },
-         { "0.85", NULL },
-         { "0.86", NULL },
-         { "0.87", NULL },
-         { "0.88", NULL },
-         { "0.89", NULL },
-         { "0.90", NULL },
-         { "0.91", NULL },
-         { "0.92", NULL },
-         { "0.93", NULL },
-         { "0.94", NULL },
-         { "0.95", NULL },
-         { "0.96", NULL },
-         { "0.97", NULL },
-         { "0.98", NULL },
-         { "0.99", NULL },
-         { "1.00", NULL },
-         { "1.01", NULL },
-         { "1.02", NULL },
-         { "1.03", NULL },
-         { "1.04", NULL },
-         { "1.05", NULL },
-         { "1.06", NULL },
-         { "1.07", NULL },
-         { "1.08", NULL },
-         { "1.09", NULL },
-         { "1.10", NULL },
-         { "1.11", NULL },
-         { "1.12", NULL },
-         { "1.13", NULL },
-         { "1.14", NULL },
-         { "1.15", NULL },
-         { "1.16", NULL },
-         { "1.17", NULL },
-         { "1.18", NULL },
-         { "1.19", NULL },
-         { "1.20", NULL },
-         { "1.21", NULL },
-         { "1.22", NULL },
-         { "1.23", NULL },
-         { "1.24", NULL },
-         { "1.25", NULL },
-         { NULL, NULL },
-      },
-      "1",
-   },
-   {
-      "pcsx_rearmed_gunconadjustratioy",
-      "Guncon Adjust Ratio Y",
-      "When using Guncon mode, you can override aim in emulator if shots misaligned, this applies a ratio on the y axis.",
-      {
-         { "1", NULL },
-         { "0.75", NULL },
-         { "0.76", NULL },
-         { "0.77", NULL },
-         { "0.78", NULL },
-         { "0.79", NULL },
-         { "0.80", NULL },
-         { "0.81", NULL },
-         { "0.82", NULL },
-         { "0.83", NULL },
-         { "0.84", NULL },
-         { "0.85", NULL },
-         { "0.86", NULL },
-         { "0.87", NULL },
-         { "0.88", NULL },
-         { "0.89", NULL },
-         { "0.90", NULL },
-         { "0.91", NULL },
-         { "0.92", NULL },
-         { "0.93", NULL },
-         { "0.94", NULL },
-         { "0.95", NULL },
-         { "0.96", NULL },
-         { "0.97", NULL },
-         { "0.98", NULL },
-         { "0.99", NULL },
-         { "1.00", NULL },
-         { "1.01", NULL },
-         { "1.02", NULL },
-         { "1.03", NULL },
-         { "1.04", NULL },
-         { "1.05", NULL },
-         { "1.06", NULL },
-         { "1.07", NULL },
-         { "1.08", NULL },
-         { "1.09", NULL },
-         { "1.10", NULL },
-         { "1.11", NULL },
-         { "1.12", NULL },
-         { "1.13", NULL },
-         { "1.14", NULL },
-         { "1.15", NULL },
-         { "1.16", NULL },
-         { "1.17", NULL },
-         { "1.18", NULL },
-         { "1.19", NULL },
-         { "1.20", NULL },
-         { "1.21", NULL },
-         { "1.22", NULL },
-         { "1.23", NULL },
-         { "1.24", NULL },
-         { "1.25", NULL },
-         { NULL, NULL },
-      },
-      "1",
-   },
-   {
-      "pcsx_rearmed_dithering",
-      "Enable Dithering",
-      "If Off, disables the dithering pattern the PSX applies to combat color banding.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-#if defined HAVE_LIBNX || defined _3DS
-	  "disabled",
-#else
-      "enabled",
 #endif
-   },
-
 #ifndef DRC_DISABLE
    {
       "pcsx_rearmed_drc",
       "Dynamic Recompiler",
-      "Enables core to use dynamic recompiler or interpreter (slower) CPU instructions.",
+      NULL,
+      "Dynamically recompile PSX CPU instructions to native instructions. Much faster than using an interpreter, but may be less accurate on some platforms.",
+      NULL,
+      "system",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -536,16 +198,18 @@ struct retro_core_option_definition option_defs_us[] = {
       "enabled",
    },
 #endif
-
 #if !defined(DRC_DISABLE) && !defined(LIGHTREC)
    {
       "pcsx_rearmed_psxclock",
-      "PSX CPU Clock",
+      "PSX CPU Clock Speed",
+      NULL,
 #if defined(HAVE_PRE_ARMV7) && !defined(_3DS)
-      "Overclock or underclock the PSX clock. Default is 50",
+      "Overclock or under-clock the PSX CPU. Lower values may reduce performance requirements while higher values may improve frame rates in demanding games at the expense of increased overheads; setting the value too low or high may reduce compatibility. Default is 50.",
 #else
-      "Overclock or underclock the PSX clock. Default is 57",
+      "Overclock or under-clock the PSX CPU. Lower values may reduce performance requirements while higher values may improve frame rates in demanding games at the expense of increased overheads; setting the value too low or high may reduce compatibility. Default is 57.",
 #endif
+      NULL,
+      "system",
       {
          { "30",  NULL },
          { "31",  NULL },
@@ -627,12 +291,143 @@ struct retro_core_option_definition option_defs_us[] = {
 #endif
    },
 #endif /* !DRC_DISABLE && !LIGHTREC */
-
+   {
+      "pcsx_rearmed_dithering",
+      "Dithering Pattern",
+      NULL,
+      "Enable emulation of the dithering technique used by the PSX to smooth out color banding artifacts. Increases performance requirements.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+#if defined HAVE_LIBNX || defined _3DS
+      "disabled",
+#else
+      "enabled",
+#endif
+   },
+   {
+      "pcsx_rearmed_duping_enable",
+      "Frame Duping (Speedup)",
+      NULL,
+      "When enabled and supported by the libretro frontend, provides a small performance increase by directing the frontend to repeat the previous frame if the core has nothing new to display.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled",
+   },
+#ifdef THREAD_RENDERING
+   {
+      "pcsx_rearmed_gpu_thread_rendering",
+      "Threaded Rendering",
+      NULL,
+      "When enabled, runs GPU commands in a secondary thread. 'Synchronous' improves performance while maintaining proper frame pacing. 'Asynchronous' improves performance even further, but may cause dropped frames and increased latency. Produces best results with games that run natively at less than 60 frames per second.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "sync",     "Synchronous" },
+         { "async",    "Asynchronous" },
+         { NULL, NULL},
+      },
+      "disabled",
+   },
+#endif
+   {
+      "pcsx_rearmed_frameskip_type",
+      "Frameskip",
+      NULL,
+      "Skip frames to avoid audio buffer under-run (crackling). Improves performance at the expense of visual smoothness. 'Auto' skips frames when advised by the frontend. 'Auto (Threshold)' utilises the 'Frameskip Threshold (%)' setting. 'Fixed Interval' utilises the 'Frameskip Interval' setting.",
+      NULL,
+      "video",
+      {
+         { "disabled",       NULL },
+         { "auto",           "Auto" },
+         { "auto_threshold", "Auto (Threshold)" },
+         { "fixed_interval", "Fixed Interval" },
+         { NULL, NULL },
+      },
+      "disabled"
+   },
+   {
+      "pcsx_rearmed_frameskip_threshold",
+      "Frameskip Threshold (%)",
+      NULL,
+      "When 'Frameskip' is set to 'Auto (Threshold)', specifies the audio buffer occupancy threshold (percentage) below which frames will be skipped. Higher values reduce the risk of crackling by causing frames to be dropped more frequently.",
+      NULL,
+      "video",
+      {
+         { "15", NULL },
+         { "18", NULL },
+         { "21", NULL },
+         { "24", NULL },
+         { "27", NULL },
+         { "30", NULL },
+         { "33", NULL },
+         { "36", NULL },
+         { "39", NULL },
+         { "42", NULL },
+         { "45", NULL },
+         { "48", NULL },
+         { "51", NULL },
+         { "54", NULL },
+         { "57", NULL },
+         { "60", NULL },
+         { NULL, NULL },
+      },
+      "33"
+   },
+   {
+      "pcsx_rearmed_frameskip_interval",
+      "Frameskip Interval",
+      NULL,
+      "Specify the maximum number of frames that can be skipped before a new frame is rendered.",
+      NULL,
+      "video",
+      {
+         { "1",  NULL },
+         { "2",  NULL },
+         { "3",  NULL },
+         { "4",  NULL },
+         { "5",  NULL },
+         { "6",  NULL },
+         { "7",  NULL },
+         { "8",  NULL },
+         { "9",  NULL },
+         { "10", NULL },
+         { NULL, NULL },
+      },
+      "3"
+   },
+   {
+      "pcsx_rearmed_display_internal_fps",
+      "Display Internal FPS",
+      NULL,
+      "Show the internal frame rate at which the emulated PlayStation system is rendering content. Note: Requires on-screen notifications to be enabled in the libretro frontend.",
+      NULL,
+      "video",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
+   },
 #ifdef GPU_NEON
    {
       "pcsx_rearmed_neon_interlace_enable",
-      "Enable Interlacing Mode",
-      "Enables fake scanlines effect.",
+      "(GPU) Show Interlaced Video",
+      "Show Interlaced Video",
+      "When enabled, games that run in high resolution video modes (480i, 512i) will produced interlaced video output. While this displays correctly on CRT televisions, it will produce artifacts on modern displays. When disabled, all video is output in progressive format.",
+      NULL,
+      "gpu_neon",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -642,8 +437,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_neon_enhancement_enable",
+      "(GPU) Enhanced Resolution (Slow)",
       "Enhanced Resolution (Slow)",
-      "Renders in double resolution at the cost of lower performance.",
+      "Render games that do not already run in high resolution video modes (480i, 512i) at twice the native internal resolution. Improves the fidelity of 3D models at the expense of increased performance requirements. 2D elements are generally unaffected by this setting.",
+      NULL,
+      "gpu_neon",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -653,8 +451,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_neon_enhancement_no_main",
-      "Enhanced Resolution (Speed Hack)",
-      "Speed hack for Enhanced resolution option (glitches some games).",
+      "(GPU) Enhanced Resolution Speed Hack",
+      "Enhanced Resolution Speed Hack",
+      "Improves performance when 'Enhanced Resolution (Slow)' is enabled, but reduces compatibility and may cause rendering errors.",
+      NULL,
+      "gpu_neon",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -663,36 +464,14 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled",
    },
 #endif /* GPU_NEON */
-
-   {
-      "pcsx_rearmed_duping_enable",
-      "Frame Duping",
-      "A speedup, redraws/reuses the last frame if there was no new data.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "enabled",
-   },
-   {
-      "pcsx_rearmed_display_internal_fps",
-      "Display Internal FPS",
-      "Shows an on-screen frames per second counter when enabled.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled",
-   },
-
-   /* GPU PEOPS OPTIONS */
 #ifdef GPU_PEOPS
    {
       "pcsx_rearmed_show_gpu_peops_settings",
-      "Advanced GPU P.E.Op.S. Settings",
-      "Shows or hides advanced GPU plugin settings. NOTE: Quick Menu must be toggled for this setting to take effect.",
+      "Show Advanced P.E.Op.S. GPU Settings",
+      NULL,
+      "Show low-level configuration options for the P.E.Op.S. GPU plugin. Quick Menu may need to be toggled for this setting to take effect.",
+      NULL,
+      NULL,
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -703,7 +482,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "pcsx_rearmed_gpu_peops_odd_even_bit",
       "(GPU) Odd/Even Bit Hack",
-      "Needed for Chrono Cross.",
+      "Odd/Even Bit Hack",
+      "A hack fix used to correct lock-ups that may occur in games such as Chrono Cross. Disable unless required.",
+      NULL,
+      "gpu_peops",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -714,7 +496,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "pcsx_rearmed_gpu_peops_expand_screen_width",
       "(GPU) Expand Screen Width",
-      "Capcom fighting games",
+      "Expand Screen Width",
+      "Intended for use only with Capcom 2D fighting games. Enlarges the display area at the right side of the screen to show all background elements without cut-off. May cause rendering errors.",
+      NULL,
+      "gpu_peops",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -725,7 +510,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "pcsx_rearmed_gpu_peops_ignore_brightness",
       "(GPU) Ignore Brightness Color",
-      "Black screens in Lunar Silver Star Story games",
+      "Ignore Brightness Color",
+      "A hack fix used to repair black screens in Lunar Silver Star Story Complete when entering a house or a menu. Disable unless required.",
+      NULL,
+      "gpu_peops",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -736,7 +524,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "pcsx_rearmed_gpu_peops_disable_coord_check",
       "(GPU) Disable Coordinate Check",
-      "Compatibility mode",
+      "Disable Coordinate Check",
+      "Legacy compatibility mode. May improve games that fail to run correctly on newer GPU hardware. Disable unless required.",
+      NULL,
+      "gpu_peops",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -747,7 +538,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "pcsx_rearmed_gpu_peops_lazy_screen_update",
       "(GPU) Lazy Screen Update",
-      "Pandemonium 2",
+      "Lazy Screen Update",
+      "A partial fix to prevent text box flickering in Dragon Warrior VII. May also improve Pandemonium 2. Disable unless required.",
+      NULL,
+      "gpu_peops",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -756,20 +550,12 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled",
    },
    {
-      "pcsx_rearmed_gpu_peops_old_frame_skip",
-      "(GPU) Old Frame Skipping",
-      "Skip every second frame",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "enabled",
-   },
-   {
       "pcsx_rearmed_gpu_peops_repeated_triangles",
-      "(GPU) Repeated Flat Tex Triangles",
-      "Needed by Star Wars: Dark Forces",
+      "(GPU) Repeat Flat Tex Triangles",
+      "Repeat Flat Tex Triangles",
+      "A hack fix used to correct rendering errors in Star Wars: Dark Forces. Disable unless required.",
+      NULL,
+      "gpu_peops",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -779,8 +565,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_gpu_peops_quads_with_triangles",
-      "(GPU) Draw Quads with Triangles",
-      "Better g-colors, worse textures",
+      "(GPU) Draw Tex-Quads as Triangles",
+      "Draw Tex-Quads as Triangles",
+      "Corrects graphical distortions that may occur when games utilize Gouraud Shading, at the expense of reduced texture quality. Disable unless required.",
+      NULL,
+      "gpu_peops",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -790,8 +579,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_gpu_peops_fake_busy_state",
-      "(GPU) Fake 'Gpu Busy' States",
-      "Toggle busy flags after drawing",
+      "(GPU) Fake 'GPU Busy' States",
+      "Fake 'GPU Busy' States",
+      "Emulate the 'GPU is busy' (drawing primitives) status flag of the original hardware instead of assuming the GPU is always ready for commands. May improve compatibility at the expense of reduced performance. Disable unless required.",
+      NULL,
+      "gpu_peops",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -799,14 +591,15 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled",
    },
-#endif
-
-    /* GPU UNAI Advanced Options */
+#endif /* GPU_PEOPS */
 #ifdef GPU_UNAI
    {
       "pcsx_rearmed_show_gpu_unai_settings",
-      "Advance GPU UNAI/PCSX4All Settings",
-      "Shows or hides advanced gpu settings. A core restart might be needed for settings to take effect. NOTE: Quick Menu must be toggled for this setting to take effect.",
+      "Show Advanced UNAI GPU Settings",
+      NULL,
+      "Show low-level configuration options for the UNAI GPU plugin. Quick Menu may need to be toggled for this setting to take effect.",
+      NULL,
+      NULL,
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -816,8 +609,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_gpu_unai_blending",
-      "(GPU) Enable Blending",
+      "(GPU) Texture Blending",
+      "Texture Blending",
+      "Enable alpha-based (and additive) texture blending. Required for various rendering effects, including transparency (e.g. water, shadows). Can be disabled to improve performance at the expense of severe display errors/inaccuracies.",
       NULL,
+      "gpu_unai",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -827,8 +623,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_gpu_unai_lighting",
-      "(GPU) Enable Lighting",
+      "(GPU) Lighting Effects",
+      "Lighting Effects",
+      "Enable simulated lighting effects (via vertex coloring combined with texture mapping). Required by almost all 3D games. Can be disabled to improve performance at the expense of severe display errors/inaccuracies (missing shadows, flat textures, etc.).",
       NULL,
+      "gpu_unai",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -838,30 +637,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_gpu_unai_fast_lighting",
-      "(GPU) Enable Fast Lighting",
+      "(GPU) Fast Lighting",
+      "Fast Lighting",
+      "Improves performance when 'Lighting Effects' are enabled, but may cause moderate/severe rendering errors.",
       NULL,
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
-      },
-      "disabled",
-   },
-   {
-      "pcsx_rearmed_gpu_unai_ilace_force",
-      "(GPU) Enable Forced Interlace",
-      NULL,
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL},
-      },
-      "disabled",
-   },
-   {
-      "pcsx_rearmed_gpu_unai_pixel_skip",
-      "(GPU) Enable Pixel Skip",
-      NULL,
+      "gpu_unai",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -871,8 +651,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_gpu_unai_scale_hires",
-      "(GPU) Enable Hi-Res Downscaling",
-      "When enabled, will scale hi-res modes to 320x240, skipping unrendered pixels.",
+      "(GPU) Hi-Res Downscaling",
+      "Hi-Res Downscaling",
+      "When enabled, games that run in high resolution video modes (480i, 512i) will be downscaled to 320x240. Can improve performance, and is recommended on devices with native 240p display resolutions.",
+      NULL,
+      "gpu_unai",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -884,37 +667,14 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled",
 #endif
    },
-#endif /* GPU UNAI Advanced Settings */
-#ifdef THREAD_RENDERING
-   {
-      "pcsx_rearmed_gpu_thread_rendering",
-      "Threaded Rendering",
-      "When enabled, runs GPU commands in a thread. Sync waits for drawing to finish before vsync. Async will not wait unless there's another frame behind it.",
-      {
-         { "disabled", NULL },
-         { "sync",  NULL },
-         { "async",  NULL },
-         { NULL, NULL},
-      },
-      "disabled",
-   },
-#endif
-
-   {
-      "pcsx_rearmed_show_bios_bootlogo",
-      "Show Bios Bootlogo",
-      "When enabled, shows the PlayStation logo when starting or resetting. (Breaks some games).",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled",
-   },
+#endif /* GPU_UNAI */
    {
       "pcsx_rearmed_spu_reverb",
-      "Sound Reverb",
-      "Enables or disables audio reverb effect.",
+      "Audio Reverb Effects",
+      "Reverb Effects",
+      "Enable emulation of the reverb feature provided by the PSX SPU. Can be disabled to improve performance at the expense of reduced audio quality/authenticity.",
+      NULL,
+      "audio",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -930,6 +690,9 @@ struct retro_core_option_definition option_defs_us[] = {
       "pcsx_rearmed_spu_interpolation",
       "Sound Interpolation",
       NULL,
+      "Enable emulation of the in-built audio interpolation provided by the PSX SPU. 'Gaussian' sounds closest to original hardware. 'Simple' improves performance but reduces quality. 'Cubic' has the highest performance requirements but produces increased clarity. Can be disabled entirely for maximum performance, at the expense of greatly reduced audio quality.",
+      NULL,
+      "audio",
       {
          { "simple",   "Simple" },
          { "gaussian", "Gaussian" },
@@ -944,8 +707,39 @@ struct retro_core_option_definition option_defs_us[] = {
 #endif
    },
    {
-      "pcsx_rearmed_pe2_fix",
-      "Parasite Eve 2/Vandal Hearts 1/2 Fix",
+      "pcsx_rearmed_nocdaudio",
+      "CD Audio",
+      NULL,
+      "Enable playback of CD (CD-DA) audio tracks. Can be disabled to improve performance in games that include CD audio, at the expense of missing music.",
+      NULL,
+      "audio",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled",
+   },
+   {
+      "pcsx_rearmed_noxadecoding",
+      "XA Decoding",
+      NULL,
+      "Enable playback of XA (eXtended Architecture ADPCM) audio tracks. Can be disabled to improve performance in games that include XA audio, at the expense of missing music.",
+      NULL,
+      "audio",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled",
+   },
+   {
+      "pcsx_rearmed_show_input_settings",
+      "Show Input Settings",
+      NULL,
+      "Show configuration options for all input devices: analog response, Multitaps, light guns, etc. Quick Menu may need to be toggled for this setting to take effect.",
+      NULL,
       NULL,
       {
          { "disabled", NULL },
@@ -955,9 +749,399 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled",
    },
    {
-      "pcsx_rearmed_icache_emulation",
-      "Instruction Cache emulation",
-      "Enables or disables instruction cache emulation. Slower, but more accurate. Fails to run Spyro 2 PAL. This allows you to run F1 2001, Formula One Arcade, F1 99 and other games that may need instruction cache emulation. Interpreter only and partial on lightrec, does nothing on the ARMv7 backend.",
+      "pcsx_rearmed_analog_axis_modifier",
+      "Analog Axis Bounds",
+      NULL,
+      "Specify range limits for the left and right analog sticks when input device is set to 'analog' or 'dualshock'. 'Square' bounds improve input response when using controllers with highly circular ranges that are unable to fully saturate the X and Y axes at 45 degree deflections.",
+      NULL,
+      "input",
+      {
+         { "circle", "Circle" },
+         { "square", "Square" },
+         { NULL, NULL },
+      },
+      "circle",
+   },
+   {
+      "pcsx_rearmed_vibration",
+      "Rumble Effects",
+      NULL,
+      "Enable haptic feedback when using a rumble-equipped gamepad with input device set to 'dualshock'.",
+      NULL,
+      "input",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "enabled",
+   },
+   {
+      "pcsx_rearmed_multitap",
+      "Multitap Mode (Restart)",
+      NULL,
+      "Connect a virtual PSX Multitap peripheral to either controller 'Port 1' or controller 'Port 2' for 5 player simultaneous input, or to both 'Ports 1 and 2' for 8 player input. Mutlitap usage requires compatible games. To avoid input defects, option should be disabled when running games that have no support for Multitap features.",
+      NULL,
+      "input",
+      {
+         { "disabled",      NULL },
+         { "port 1",        "Port 1" },
+         { "port 2",        "Port 2" },
+         { "ports 1 and 2", "Ports 1 and 2" },
+         { NULL, NULL },
+      },
+      "disabled",
+   },
+   {
+      "pcsx_rearmed_negcon_deadzone",
+      "NegCon Twist Deadzone",
+      NULL,
+      "Set the deadzone of the RetroPad left analog stick when simulating the 'twist' action of emulated neGcon Controllers. Used to eliminate drift/unwanted input.",
+      NULL,
+      "input",
+      {
+         { "0",  "0%" },
+         { "3",  "3%" },
+         { "5",  "5%" },
+         { "7",  "7%" },
+         { "10", "10%" },
+         { "13", "13%" },
+         { "15", "15%" },
+         { "17", "17%" },
+         { "20", "20%" },
+         { "23", "23%" },
+         { "25", "25%" },
+         { "27", "27%" },
+         { "30", "30%" },
+         { NULL, NULL },
+      },
+      "0",
+   },
+   {
+      "pcsx_rearmed_negcon_response",
+      "NegCon Twist Response",
+      NULL,
+      "Specify the analog response when using a RetroPad left analog stick to simulate the 'twist' action of emulated neGcon Controllers.",
+      NULL,
+      "input",
+      {
+         { "linear",    "Linear" },
+         { "quadratic", "Quadratic" },
+         { "cubic",     "Cubic" },
+         { NULL, NULL },
+      },
+      "linear",
+   },
+   {
+      "pcsx_rearmed_input_sensitivity",
+      "Mouse Sensitivity",
+      NULL,
+      "Adjust responsiveness of emulated 'mouse' input devices.",
+      NULL,
+      "input",
+      {
+         { "0.05", NULL },
+         { "0.10", NULL },
+         { "0.15", NULL },
+         { "0.20", NULL },
+         { "0.25", NULL },
+         { "0.30", NULL },
+         { "0.35", NULL },
+         { "0.40", NULL },
+         { "0.45", NULL },
+         { "0.50", NULL },
+         { "0.55", NULL },
+         { "0.60", NULL },
+         { "0.65", NULL },
+         { "0.70", NULL },
+         { "0.75", NULL },
+         { "0.80", NULL },
+         { "0.85", NULL },
+         { "0.90", NULL },
+         { "0.95", NULL },
+         { "1.00", NULL },
+         { "1.05", NULL },
+         { "1.10", NULL },
+         { "1.15", NULL },
+         { "1.20", NULL },
+         { "1.25", NULL },
+         { "1.30", NULL },
+         { "1.35", NULL },
+         { "1.40", NULL },
+         { "1.45", NULL },
+         { "1.50", NULL },
+         { "1.55", NULL },
+         { "1.60", NULL },
+         { "1.65", NULL },
+         { "1.70", NULL },
+         { "1.75", NULL },
+         { "1.80", NULL },
+         { "1.85", NULL },
+         { "1.90", NULL },
+         { "1.95", NULL },
+         { "2.00", NULL },
+      },
+      "1.00",
+   },
+   {
+      "pcsx_rearmed_gunconadjustx",
+      "Guncon X Axis Offset",
+      NULL,
+      "Apply an X axis offset to light gun input when emulating a Guncon device. Can be used to correct aiming misalignments.",
+      NULL,
+      "input",
+      {
+         { "-25", NULL },
+         { "-24", NULL },
+         { "-23", NULL },
+         { "-22", NULL },
+         { "-21", NULL },
+         { "-20", NULL },
+         { "-19", NULL },
+         { "-18", NULL },
+         { "-17", NULL },
+         { "-16", NULL },
+         { "-15", NULL },
+         { "-14", NULL },
+         { "-13", NULL },
+         { "-12", NULL },
+         { "-11", NULL },
+         { "-10", NULL },
+         { "-9",  NULL },
+         { "-8",  NULL },
+         { "-7",  NULL },
+         { "-6",  NULL },
+         { "-5",  NULL },
+         { "-4",  NULL },
+         { "-3",  NULL },
+         { "-2",  NULL },
+         { "-1",  NULL },
+         { "0",   NULL },
+         { "1",   NULL },
+         { "2",   NULL },
+         { "3",   NULL },
+         { "4",   NULL },
+         { "5",   NULL },
+         { "6",   NULL },
+         { "7",   NULL },
+         { "8",   NULL },
+         { "9",   NULL },
+         { "10",  NULL },
+         { "11",  NULL },
+         { "12",  NULL },
+         { "13",  NULL },
+         { "14",  NULL },
+         { "15",  NULL },
+         { "16",  NULL },
+         { "17",  NULL },
+         { "18",  NULL },
+         { "19",  NULL },
+         { "20",  NULL },
+         { "21",  NULL },
+         { "22",  NULL },
+         { "23",  NULL },
+         { "24",  NULL },
+         { "25",  NULL },
+         { NULL, NULL },
+      },
+      "0",
+   },
+   {
+      "pcsx_rearmed_gunconadjusty",
+      "Guncon Y Axis Offset",
+      NULL,
+      "Apply a Y axis offset to light gun input when emulating a Guncon device. Can be used to correct aiming misalignments.",
+      NULL,
+      "input",
+      {
+         { "-25", NULL },
+         { "-24", NULL },
+         { "-23", NULL },
+         { "-22", NULL },
+         { "-21", NULL },
+         { "-20", NULL },
+         { "-19", NULL },
+         { "-18", NULL },
+         { "-17", NULL },
+         { "-16", NULL },
+         { "-15", NULL },
+         { "-14", NULL },
+         { "-13", NULL },
+         { "-12", NULL },
+         { "-11", NULL },
+         { "-10", NULL },
+         { "-9",  NULL },
+         { "-8",  NULL },
+         { "-7",  NULL },
+         { "-6",  NULL },
+         { "-5",  NULL },
+         { "-4",  NULL },
+         { "-3",  NULL },
+         { "-2",  NULL },
+         { "-1",  NULL },
+         { "0",   NULL },
+         { "1",   NULL },
+         { "2",   NULL },
+         { "3",   NULL },
+         { "4",   NULL },
+         { "5",   NULL },
+         { "6",   NULL },
+         { "7",   NULL },
+         { "8",   NULL },
+         { "9",   NULL },
+         { "10",  NULL },
+         { "11",  NULL },
+         { "12",  NULL },
+         { "13",  NULL },
+         { "14",  NULL },
+         { "15",  NULL },
+         { "16",  NULL },
+         { "17",  NULL },
+         { "18",  NULL },
+         { "19",  NULL },
+         { "20",  NULL },
+         { "21",  NULL },
+         { "22",  NULL },
+         { "23",  NULL },
+         { "24",  NULL },
+         { "25",  NULL },
+         { NULL, NULL },
+      },
+      "0",
+   },
+   {
+      "pcsx_rearmed_gunconadjustratiox",
+      "Guncon X Axis Response",
+      NULL,
+      "Adjust relative magnitude of horizontal light gun motion when emulating a Guncon device. Can be used to correct aiming misalignments.",
+      NULL,
+      "input",
+      {
+         { "0.75", NULL },
+         { "0.76", NULL },
+         { "0.77", NULL },
+         { "0.78", NULL },
+         { "0.79", NULL },
+         { "0.80", NULL },
+         { "0.81", NULL },
+         { "0.82", NULL },
+         { "0.83", NULL },
+         { "0.84", NULL },
+         { "0.85", NULL },
+         { "0.86", NULL },
+         { "0.87", NULL },
+         { "0.88", NULL },
+         { "0.89", NULL },
+         { "0.90", NULL },
+         { "0.91", NULL },
+         { "0.92", NULL },
+         { "0.93", NULL },
+         { "0.94", NULL },
+         { "0.95", NULL },
+         { "0.96", NULL },
+         { "0.97", NULL },
+         { "0.98", NULL },
+         { "0.99", NULL },
+         { "1.00", NULL },
+         { "1.01", NULL },
+         { "1.02", NULL },
+         { "1.03", NULL },
+         { "1.04", NULL },
+         { "1.05", NULL },
+         { "1.06", NULL },
+         { "1.07", NULL },
+         { "1.08", NULL },
+         { "1.09", NULL },
+         { "1.10", NULL },
+         { "1.11", NULL },
+         { "1.12", NULL },
+         { "1.13", NULL },
+         { "1.14", NULL },
+         { "1.15", NULL },
+         { "1.16", NULL },
+         { "1.17", NULL },
+         { "1.18", NULL },
+         { "1.19", NULL },
+         { "1.20", NULL },
+         { "1.21", NULL },
+         { "1.22", NULL },
+         { "1.23", NULL },
+         { "1.24", NULL },
+         { "1.25", NULL },
+         { NULL, NULL },
+      },
+      "1.00",
+   },
+   {
+      "pcsx_rearmed_gunconadjustratioy",
+      "Guncon Y Axis Response",
+      NULL,
+      "Adjust relative magnitude of vertical light gun motion when emulating a Guncon device. Can be used to correct aiming misalignments.",
+      NULL,
+      "input",
+      {
+         { "0.75", NULL },
+         { "0.76", NULL },
+         { "0.77", NULL },
+         { "0.78", NULL },
+         { "0.79", NULL },
+         { "0.80", NULL },
+         { "0.81", NULL },
+         { "0.82", NULL },
+         { "0.83", NULL },
+         { "0.84", NULL },
+         { "0.85", NULL },
+         { "0.86", NULL },
+         { "0.87", NULL },
+         { "0.88", NULL },
+         { "0.89", NULL },
+         { "0.90", NULL },
+         { "0.91", NULL },
+         { "0.92", NULL },
+         { "0.93", NULL },
+         { "0.94", NULL },
+         { "0.95", NULL },
+         { "0.96", NULL },
+         { "0.97", NULL },
+         { "0.98", NULL },
+         { "0.99", NULL },
+         { "1.00", NULL },
+         { "1.01", NULL },
+         { "1.02", NULL },
+         { "1.03", NULL },
+         { "1.04", NULL },
+         { "1.05", NULL },
+         { "1.06", NULL },
+         { "1.07", NULL },
+         { "1.08", NULL },
+         { "1.09", NULL },
+         { "1.10", NULL },
+         { "1.11", NULL },
+         { "1.12", NULL },
+         { "1.13", NULL },
+         { "1.14", NULL },
+         { "1.15", NULL },
+         { "1.16", NULL },
+         { "1.17", NULL },
+         { "1.18", NULL },
+         { "1.19", NULL },
+         { "1.20", NULL },
+         { "1.21", NULL },
+         { "1.22", NULL },
+         { "1.23", NULL },
+         { "1.24", NULL },
+         { "1.25", NULL },
+         { NULL, NULL },
+      },
+      "1.00",
+   },
+   {
+      "pcsx_rearmed_pe2_fix",
+      "Parasite Eve 2/Vandal Hearts 1/2 Fix",
+      NULL,
+      "Hack fix required for correct operation of Parasite Eve 2 and Vandal Hearts 1/2. Should be disabled for all other games.",
+      NULL,
+      "compat_hack",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -969,54 +1153,23 @@ struct retro_core_option_definition option_defs_us[] = {
       "pcsx_rearmed_inuyasha_fix",
       "InuYasha Sengoku Battle Fix",
       NULL,
+      "Hack fix required for correct operation of Inuyasha Sengoku Otogi Kassen. Should be disabled for all other games.",
+      NULL,
+      "compat_hack",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
          { NULL, NULL },
       },
       "disabled",
-   },
-#ifndef _WIN32
-   {
-      "pcsx_rearmed_async_cd",
-      "CD Access Method (Restart)",
-      "Select method used to read data from content disk images. 'Synchronous' mimics original hardware. 'Asynchronous' can reduce stuttering on devices with slow storage. 'Precache' loads disk image into memory for faster access (CHD only).",
-      {
-         { "sync",     "Synchronous" },
-         { "async",    "Asynchronous" },
-         { "precache", "Precache" },
-         { NULL, NULL},
-      },
-      "sync",
-   },
-#endif
-   /* ADVANCED OPTIONS */
-   {
-      "pcsx_rearmed_noxadecoding",
-      "XA Decoding",
-      NULL,
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "enabled",
-   },
-   {
-      "pcsx_rearmed_nocdaudio",
-      "CD Audio",
-      NULL,
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "enabled",
    },
    {
       "pcsx_rearmed_spuirq",
       "SPU IRQ Always Enabled",
-      "Compatibility tweak, should be left to off in most cases.",
+      NULL,
+      "Hack for certain games where events tied to audio cues do not trigger correctly. Fixes unopenable doors in Alien Resurrection. Fixes desynchronised FMV audio in Legend of Mana. Should be disabled unless required.",
+      NULL,
+      "compat_hack",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -1024,12 +1177,42 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled",
    },
-
+   {
+      "pcsx_rearmed_icache_emulation",
+      "Instruction Cache Emulation",
+      NULL,
+      "Enable emulation of the PSX CPU instruction cache. Improves accuracy at the expense of increased performance overheads. Required for Formula One 2001, Formula One Arcade and Formula One 99. May cause certain games to fail (e.g. Spyro 2: Gateway to Glimmer, PAL version) so should be disabled unless needed. [Interpreter only and partial on lightrec, unsupported when using ARMv7 backend]",
+      NULL,
+      "compat_hack",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
+   },
 #if !defined(DRC_DISABLE) && !defined(LIGHTREC)
+   {
+      "pcsx_rearmed_nocompathacks",
+      "Disable Automatic Compatibility Hacks",
+      NULL,
+      "By default, PCSX-ReARMed will apply auxiliary compatibility hacks automatically, based on the currently loaded content. This behaviour is required for correct operation, but may be disabled if desired.",
+      NULL,
+      "compat_hack",
+      {
+         { "disabled", NULL },
+         { "enabled",  NULL },
+         { NULL, NULL },
+      },
+      "disabled",
+   },
    {
       "pcsx_rearmed_nosmccheck",
       "(Speed Hack) Disable SMC Checks",
-      "Will cause crashes when loading, break memcards.",
+      "Disable SMC Checks",
+      "Will cause crashes when loading, and lead to memory card failure.",
+      NULL,
+      "speed_hack",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -1039,8 +1222,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_gteregsunneeded",
-      "(Speed Hack) Assume GTE Regs Unneeded",
-      "May cause graphical glitches.",
+      "(Speed Hack) Assume GTE Registers Unneeded",
+      "Assume GTE Registers Unneeded",
+      "May cause rendering errors.",
+      NULL,
+      "speed_hack",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -1051,7 +1237,10 @@ struct retro_core_option_definition option_defs_us[] = {
    {
       "pcsx_rearmed_nogteflags",
       "(Speed Hack) Disable GTE Flags",
-      "Will cause graphical glitches.",
+      "Disable GTE Flags",
+      "Will cause rendering errors.",
+      NULL,
+      "speed_hack",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -1061,19 +1250,11 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "pcsx_rearmed_nostalls",
-      "Disable CPU/GTE stalls",
-      "Will cause some games to run too fast.",
-      {
-         { "disabled", NULL },
-         { "enabled",  NULL },
-         { NULL, NULL },
-      },
-      "disabled",
-   },
-   {
-      "pcsx_rearmed_nocompathacks",
-      "Disable compat hacks",
-      "Disables game-specific compatibility hacks.",
+      "(Speed Hack) Disable CPU/GTE Stalls",
+      "Disable CPU/GTE Stalls",
+      "Will cause some games to run too quickly.",
+      NULL,
+      "speed_hack",
       {
          { "disabled", NULL },
          { "enabled",  NULL },
@@ -1082,8 +1263,12 @@ struct retro_core_option_definition option_defs_us[] = {
       "disabled",
    },
 #endif /* !DRC_DISABLE && !LIGHTREC */
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
 
-   { NULL, NULL, NULL, {{0}}, NULL },
+struct retro_core_options_v2 options_us = {
+   option_cats_us,
+   option_defs_us
 };
 
 /*
@@ -1093,26 +1278,26 @@ struct retro_core_option_definition option_defs_us[] = {
 */
 
 #ifndef HAVE_NO_LANGEXTRA
-struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
-   option_defs_us, /* RETRO_LANGUAGE_ENGLISH */
-   NULL,           /* RETRO_LANGUAGE_JAPANESE */
-   NULL,           /* RETRO_LANGUAGE_FRENCH */
-   NULL,           /* RETRO_LANGUAGE_SPANISH */
-   NULL,           /* RETRO_LANGUAGE_GERMAN */
-   NULL,           /* RETRO_LANGUAGE_ITALIAN */
-   NULL,           /* RETRO_LANGUAGE_DUTCH */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
-   NULL,           /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
-   NULL,           /* RETRO_LANGUAGE_RUSSIAN */
-   NULL,           /* RETRO_LANGUAGE_KOREAN */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
-   NULL,           /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
-   NULL,           /* RETRO_LANGUAGE_ESPERANTO */
-   NULL,           /* RETRO_LANGUAGE_POLISH */
-   NULL,           /* RETRO_LANGUAGE_VIETNAMESE */
-   NULL,           /* RETRO_LANGUAGE_ARABIC */
-   NULL,           /* RETRO_LANGUAGE_GREEK */
-   option_defs_tr, /* RETRO_LANGUAGE_TURKISH */
+struct retro_core_options_v2 *options_intl[RETRO_LANGUAGE_LAST] = {
+   &options_us, /* RETRO_LANGUAGE_ENGLISH */
+   NULL,        /* RETRO_LANGUAGE_JAPANESE */
+   NULL,        /* RETRO_LANGUAGE_FRENCH */
+   NULL,        /* RETRO_LANGUAGE_SPANISH */
+   NULL,        /* RETRO_LANGUAGE_GERMAN */
+   NULL,        /* RETRO_LANGUAGE_ITALIAN */
+   NULL,        /* RETRO_LANGUAGE_DUTCH */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_BRAZIL */
+   NULL,        /* RETRO_LANGUAGE_PORTUGUESE_PORTUGAL */
+   NULL,        /* RETRO_LANGUAGE_RUSSIAN */
+   NULL,        /* RETRO_LANGUAGE_KOREAN */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_TRADITIONAL */
+   NULL,        /* RETRO_LANGUAGE_CHINESE_SIMPLIFIED */
+   NULL,        /* RETRO_LANGUAGE_ESPERANTO */
+   NULL,        /* RETRO_LANGUAGE_POLISH */
+   NULL,        /* RETRO_LANGUAGE_VIETNAMESE */
+   NULL,        /* RETRO_LANGUAGE_ARABIC */
+   NULL,        /* RETRO_LANGUAGE_GREEK */
+   &options_tr, /* RETRO_LANGUAGE_TURKISH */
 };
 #endif
 
@@ -1130,45 +1315,61 @@ struct retro_core_option_definition *option_defs_intl[RETRO_LANGUAGE_LAST] = {
  *   be as painless as possible for core devs)
  */
 
-static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
+static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
+      bool *categories_supported)
 {
-   unsigned version = 0;
+   unsigned version  = 0;
+#ifndef HAVE_NO_LANGEXTRA
+   unsigned language = 0;
+#endif
 
-   if (!environ_cb)
+   if (!environ_cb || !categories_supported)
       return;
 
-   if (environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version) && (version >= 1))
+   *categories_supported = false;
+
+   if (!environ_cb(RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION, &version))
+      version = 0;
+
+   if (version >= 2)
    {
 #ifndef HAVE_NO_LANGEXTRA
-      struct retro_core_options_intl core_options_intl;
-      unsigned language = 0;
+      struct retro_core_options_v2_intl core_options_intl;
 
-      core_options_intl.us    = option_defs_us;
+      core_options_intl.us    = &options_us;
       core_options_intl.local = NULL;
 
       if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
           (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH))
-         core_options_intl.local = option_defs_intl[language];
+         core_options_intl.local = options_intl[language];
 
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_intl);
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL,
+            &core_options_intl);
 #else
-      environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, &option_defs_us);
+      *categories_supported = environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+            &options_us);
 #endif
    }
    else
    {
-      size_t i;
+      size_t i, j;
       size_t option_index              = 0;
       size_t num_options               = 0;
+      struct retro_core_option_definition
+            *option_v1_defs_us         = NULL;
+#ifndef HAVE_NO_LANGEXTRA
+      size_t num_options_intl          = 0;
+      struct retro_core_option_v2_definition
+            *option_defs_intl          = NULL;
+      struct retro_core_option_definition
+            *option_v1_defs_intl       = NULL;
+      struct retro_core_options_intl
+            core_options_v1_intl;
+#endif
       struct retro_variable *variables = NULL;
       char **values_buf                = NULL;
 
-      /* Determine number of options
-       * > Note: We are going to skip a number of irrelevant
-       *   core options when building the retro_variable array,
-       *   but we'll allocate space for all of them. The difference
-       *   in resource usage is negligible, and this allows us to
-       *   keep the code 'cleaner' */
+      /* Determine total number of options */
       while (true)
       {
          if (option_defs_us[num_options].key)
@@ -1177,92 +1378,194 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb)
             break;
       }
 
-      /* Allocate arrays */
-      variables  = (struct retro_variable *)calloc(num_options + 1, sizeof(struct retro_variable));
-      values_buf = (char **)calloc(num_options, sizeof(char *));
-
-      if (!variables || !values_buf)
-         goto error;
-
-      /* Copy parameters from option_defs_us array */
-      for (i = 0; i < num_options; i++)
+      if (version >= 1)
       {
-         const char *key                        = option_defs_us[i].key;
-         const char *desc                       = option_defs_us[i].desc;
-         const char *default_value              = option_defs_us[i].default_value;
-         struct retro_core_option_value *values = option_defs_us[i].values;
-         size_t buf_len                         = 3;
-         size_t default_index                   = 0;
+         /* Allocate US array */
+         option_v1_defs_us = (struct retro_core_option_definition *)
+               calloc(num_options + 1, sizeof(struct retro_core_option_definition));
 
-         values_buf[i] = NULL;
-
-         /* Skip options that are irrelevant when using the
-          * old style core options interface */
-         if ((strcmp(key, "pcsx_rearmed_show_gpu_peops_settings") == 0))
-            continue;
-
-         if (desc)
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
          {
-            size_t num_values = 0;
+            struct retro_core_option_v2_definition *option_def_us = &option_defs_us[i];
+            struct retro_core_option_value *option_values         = option_def_us->values;
+            struct retro_core_option_definition *option_v1_def_us = &option_v1_defs_us[i];
+            struct retro_core_option_value *option_v1_values      = option_v1_def_us->values;
 
-            /* Determine number of values */
+            option_v1_def_us->key           = option_def_us->key;
+            option_v1_def_us->desc          = option_def_us->desc;
+            option_v1_def_us->info          = option_def_us->info;
+            option_v1_def_us->default_value = option_def_us->default_value;
+
+            /* Values must be copied individually... */
+            while (option_values->value)
+            {
+               option_v1_values->value = option_values->value;
+               option_v1_values->label = option_values->label;
+
+               option_values++;
+               option_v1_values++;
+            }
+         }
+
+#ifndef HAVE_NO_LANGEXTRA
+         if (environ_cb(RETRO_ENVIRONMENT_GET_LANGUAGE, &language) &&
+             (language < RETRO_LANGUAGE_LAST) && (language != RETRO_LANGUAGE_ENGLISH) &&
+             options_intl[language])
+            option_defs_intl = options_intl[language]->definitions;
+
+         if (option_defs_intl)
+         {
+            /* Determine number of intl options */
             while (true)
             {
-               if (values[num_values].value)
-               {
-                  /* Check if this is the default value */
-                  if (default_value)
-                     if (strcmp(values[num_values].value, default_value) == 0)
-                        default_index = num_values;
-
-                  buf_len += strlen(values[num_values].value);
-                  num_values++;
-               }
+               if (option_defs_intl[num_options_intl].key)
+                  num_options_intl++;
                else
                   break;
             }
 
-            /* Build values string */
-            if (num_values > 0)
+            /* Allocate intl array */
+            option_v1_defs_intl = (struct retro_core_option_definition *)
+                  calloc(num_options_intl + 1, sizeof(struct retro_core_option_definition));
+
+            /* Copy parameters from option_defs_intl array */
+            for (i = 0; i < num_options_intl; i++)
             {
-               size_t j;
+               struct retro_core_option_v2_definition *option_def_intl = &option_defs_intl[i];
+               struct retro_core_option_value *option_values           = option_def_intl->values;
+               struct retro_core_option_definition *option_v1_def_intl = &option_v1_defs_intl[i];
+               struct retro_core_option_value *option_v1_values        = option_v1_def_intl->values;
 
-               buf_len += num_values - 1;
-               buf_len += strlen(desc);
+               option_v1_def_intl->key           = option_def_intl->key;
+               option_v1_def_intl->desc          = option_def_intl->desc;
+               option_v1_def_intl->info          = option_def_intl->info;
+               option_v1_def_intl->default_value = option_def_intl->default_value;
 
-               values_buf[i] = (char *)calloc(buf_len, sizeof(char));
-               if (!values_buf[i])
-                  goto error;
-
-               strcpy(values_buf[i], desc);
-               strcat(values_buf[i], "; ");
-
-               /* Default value goes first */
-               strcat(values_buf[i], values[default_index].value);
-
-               /* Add remaining values */
-               for (j = 0; j < num_values; j++)
+               /* Values must be copied individually... */
+               while (option_values->value)
                {
-                  if (j != default_index)
-                  {
-                     strcat(values_buf[i], "|");
-                     strcat(values_buf[i], values[j].value);
-                  }
+                  option_v1_values->value = option_values->value;
+                  option_v1_values->label = option_values->label;
+
+                  option_values++;
+                  option_v1_values++;
                }
             }
          }
 
-         variables[option_index].key   = key;
-         variables[option_index].value = values_buf[i];
-         option_index++;
+         core_options_v1_intl.us    = option_v1_defs_us;
+         core_options_v1_intl.local = option_v1_defs_intl;
+
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL, &core_options_v1_intl);
+#else
+         environ_cb(RETRO_ENVIRONMENT_SET_CORE_OPTIONS, option_v1_defs_us);
+#endif
+      }
+      else
+      {
+         /* Allocate arrays */
+         variables  = (struct retro_variable *)calloc(num_options + 1,
+               sizeof(struct retro_variable));
+         values_buf = (char **)calloc(num_options, sizeof(char *));
+
+         if (!variables || !values_buf)
+            goto error;
+
+         /* Copy parameters from option_defs_us array */
+         for (i = 0; i < num_options; i++)
+         {
+            const char *key                        = option_defs_us[i].key;
+            const char *desc                       = option_defs_us[i].desc;
+            const char *default_value              = option_defs_us[i].default_value;
+            struct retro_core_option_value *values = option_defs_us[i].values;
+            size_t buf_len                         = 3;
+            size_t default_index                   = 0;
+
+            values_buf[i] = NULL;
+
+            /* Skip options that are irrelevant when using the
+             * old style core options interface */
+            if ((strcmp(key, "pcsx_rearmed_show_input_settings") == 0) ||
+                (strcmp(key, "pcsx_rearmed_show_gpu_peops_settings") == 0) ||
+                (strcmp(key, "pcsx_rearmed_show_gpu_unai_settings") == 0))
+               continue;
+
+            if (desc)
+            {
+               size_t num_values = 0;
+
+               /* Determine number of values */
+               while (true)
+               {
+                  if (values[num_values].value)
+                  {
+                     /* Check if this is the default value */
+                     if (default_value)
+                        if (strcmp(values[num_values].value, default_value) == 0)
+                           default_index = num_values;
+
+                     buf_len += strlen(values[num_values].value);
+                     num_values++;
+                  }
+                  else
+                     break;
+               }
+
+               /* Build values string */
+               if (num_values > 0)
+               {
+                  buf_len += num_values - 1;
+                  buf_len += strlen(desc);
+
+                  values_buf[i] = (char *)calloc(buf_len, sizeof(char));
+                  if (!values_buf[i])
+                     goto error;
+
+                  strcpy(values_buf[i], desc);
+                  strcat(values_buf[i], "; ");
+
+                  /* Default value goes first */
+                  strcat(values_buf[i], values[default_index].value);
+
+                  /* Add remaining values */
+                  for (j = 0; j < num_values; j++)
+                  {
+                     if (j != default_index)
+                     {
+                        strcat(values_buf[i], "|");
+                        strcat(values_buf[i], values[j].value);
+                     }
+                  }
+               }
+            }
+
+            variables[option_index].key   = key;
+            variables[option_index].value = values_buf[i];
+            option_index++;
+         }
+
+         /* Set variables */
+         environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
       }
 
-      /* Set variables */
-      environ_cb(RETRO_ENVIRONMENT_SET_VARIABLES, variables);
-
 error:
-
       /* Clean up */
+
+      if (option_v1_defs_us)
+      {
+         free(option_v1_defs_us);
+         option_v1_defs_us = NULL;
+      }
+
+#ifndef HAVE_NO_LANGEXTRA
+      if (option_v1_defs_intl)
+      {
+         free(option_v1_defs_intl);
+         option_v1_defs_intl = NULL;
+      }
+#endif
+
       if (values_buf)
       {
          for (i = 0; i < num_options; i++)

--- a/frontend/libretro_core_options_intl.h
+++ b/frontend/libretro_core_options_intl.h
@@ -11,9 +11,10 @@
 
 /*
  ********************************
- * VERSION: 1.3
+ * VERSION: 2.0
  ********************************
  *
+ * - 2.0: Add support for core options v2 interface
  * - 1.3: Move translations to libretro_core_options_intl.h
  *        - libretro_core_options_intl.h includes BOM and utf-8
  *          fix for MSVC 2010-2013
@@ -73,11 +74,18 @@ extern "C" {
 
 /* RETRO_LANGUAGE_TURKISH */
 
-struct retro_core_option_definition option_defs_tr[] = {
+struct retro_core_option_v2_category option_cats_tr[] = {
+   { NULL, NULL, NULL },
+};
+
+struct retro_core_option_v2_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_frameskip",
       "Kare Atlama",
+      NULL,
       "Görsel pürüzsüzlük pahasına performansı artırmak için ne kadar karenin atlanması gerektiğini seçin.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -86,10 +94,12 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_bios",
       "BIOS Kullan",
+      NULL,
       "Gerçek bios dosyasını (varsa) veya öykünmüş bios'u (HLE) kullanmanızı sağlar. Daha iyi uyumluluk için resmi bios dosyasını kullanmanız önerilir.",
+      NULL,
+      NULL,
       {
          { "auto", "otomatik" },
-         { "HLE",  "hle" },
          { NULL, NULL },
       },
       "auto",
@@ -97,11 +107,12 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_region",
       "Bölge",
+      NULL,
       "Sistemin hangi bölgeden olduğunu seçin. NTSC için 60 Hz, PAL için 50 Hz.",
+      NULL,
+      NULL,
       {
          { "auto", "otomatik" },
-         { "NTSC", "ntsc" },
-         { "PAL",  "pal" },
          { NULL, NULL },
       },
       "auto",
@@ -109,7 +120,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_memcard2",
       "İkinci Bellek Kartını Etkinleştir (Paylaşılan)",
+      NULL,
       "2. Hafıza kartı yuvasını etkinleştirin. Bu hafıza kartı tüm oyunlar arasında paylaşılır.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -118,11 +132,12 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_multitap1",
       "Multitap 1",
+      NULL,
       "Bağlantı noktası 1'deki multitap'ı etkinleştirir / devre dışı bırakır ve izin veren oyunlarda 5 oyuncuya kadar izin verir.",
+      NULL,
+      NULL,
       {
-         { "auto",     "otomatik" },
-         { "disabled", NULL },
-         { "enabled",  NULL },
+         { "auto", "otomatik" },
          { NULL, NULL },
       },
       "auto",
@@ -130,11 +145,12 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_multitap2",
       "Multitap 2",
+      NULL,
       "Bağlantı noktası 2'deki multitap'ı etkinleştirir/devre dışı bırakır ve izin veren oyunlarda 8 oyuncuya kadar izin verir. Bunun çalışması için Multitap 1'in etkinleştirilmesi gerekir.",
+      NULL,
+      NULL,
       {
-         { "auto",     "otomatik" },
-         { "disabled", NULL },
-         { "enabled",  NULL },
+         { "auto", "otomatik" },
          { NULL, NULL },
       },
       "auto",
@@ -142,7 +158,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_negcon_deadzone",
       "NegCon Twist Deadzone (Yüzdelik)",
+      NULL,
       "Öykünülmüş neGcon kontrolörünün 'büküm' eylemini simüle ederken RetroPad sol analog çubuğunun ölü bölgesini ayarlar. Sürüklenme/istenmeyen girişi ortadan kaldırmak için kullanılır.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -151,7 +170,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_negcon_response",
       "NegCon Twist Response",
+      NULL,
       "Öykünülmüş neGcon kontrolörünün 'bükümünü' simule etmek için bir RetroPad sol analog çubuğu kullanırken analog cevabını belirtir.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -160,7 +182,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_vibration",
       "Titreşimi Etkinleştir",
+      NULL,
       "Titreşim özelliklerini destekleyen kontrolörler için titreşim geri bildirimini etkinleştirir.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -169,7 +194,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_dithering",
       "Dithering Etkinleştir",
+      NULL,
       "Kapalı ise, PSX'in renk bantlarıyla mücadele etmek için uyguladığı renk taklidi düzenini devre dışı bırakır.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -180,7 +208,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_drc",
       "Dinamik Yeniden Derleyici",
+      NULL,
       "Çekirdeğin dinamik yeniden derleyici veya tercüman(daha yavaş) CPU talimatlarını kullanmasını sağlar.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -189,11 +220,14 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_psxclock",
       "PSX CPU Saat Hızı",
+      NULL,
 #ifdef HAVE_PRE_ARMV7
       "Overclock or underclock the PSX clock. Default is 50",
 #else
       "Overclock or underclock the PSX clock. Default is 57",
 #endif
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -205,7 +239,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_neon_interlace_enable",
       "Interlacing Mode'u etkinleştir",
+      NULL,
       "Sahte tarama çizgileri efektini etkinleştirir.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -214,7 +251,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_neon_enhancement_enable",
       "Geliştirilmiş Çözünürlük (Yavaş)",
+      NULL,
       "Düşük performans pahasına çift çözünürlükte işler.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -223,7 +263,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_neon_enhancement_no_main",
       "Geliştirilmiş Çözünürlük (Speed Hack)",
+      NULL,
       "Geliştirilmiş çözünürlük seçeneği için hız aşırtma(bazı oyunlarda sorun çıkartabilir).",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -234,7 +277,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_duping_enable",
       "Frame Duping",
+      NULL,
       "Yeni bir veri yoksa, bir hızlandırma, son kareyi yeniden çizer/yeniden kullanır.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -243,7 +289,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_display_internal_fps",
       "Dahili FPS'yi görüntüle",
+      NULL,
       "Etkinleştirildiğinde ekranda saniye başına kareyi gösterir.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -255,7 +304,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_show_gpu_peops_settings",
       "Gelişmiş GPU Ayarlarını Göster",
+      NULL,
       "Çeşitli GPU düzeltmelerini etkinleştirin veya devre dışı bırakın. Ayarların etkili olması için core'un yeniden başlatılması gerekebilir. NOT: Bu ayarın etkili olabilmesi için Hızlı Menü’nün değiştirilmesi gerekir.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -264,7 +316,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gpu_peops_odd_even_bit",
       "(GPU) Odd/Even Bit Hack",
+      NULL,
       "Chrono Cross için gerekli.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -273,7 +328,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gpu_peops_expand_screen_width",
       "(GPU) Ekran Genişliğini Genişlet",
+      NULL,
       "Capcom dövüş oyunları",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -282,7 +340,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gpu_peops_ignore_brightness",
       "(GPU) Parlaklık Rengini Yoksay",
+      NULL,
       "Lunar Silver Star Story oyunlarında siyah ekran",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -291,7 +352,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gpu_peops_disable_coord_check",
       "(GPU) Koordinat Kontrolünü Devre Dışı Bırak",
+      NULL,
       "Uyumluluk modu",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -300,7 +364,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gpu_peops_lazy_screen_update",
       "(GPU) Tembel Ekran Güncellemesi",
+      NULL,
       "Pandemonium 2",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -309,7 +376,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gpu_peops_old_frame_skip",
       "(GPU) Eski Çerçeve Atlama",
+      NULL,
       "Her ikinci kareyi atla",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -318,7 +388,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gpu_peops_repeated_triangles",
       "(GPU) Tekrarlanan Düz Doku Üçgenleri",
+      NULL,
       "Star Wars: Dark Forces için gerekli",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -327,7 +400,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gpu_peops_quads_with_triangles",
       "(GPU) Üçgenler ile Dörtlü Çiz",
+      NULL,
       "Daha iyi g renkler, daha kötü dokular",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -336,7 +412,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gpu_peops_fake_busy_state",
       "(GPU) Sahte 'Gpu Meşgul' Konumları",
+      NULL,
       "Çizimden sonra meşgul bayraklarını değiştir",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -347,7 +426,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_show_bios_bootlogo",
       "Bios Bootlogo'yu Göster",
+      NULL,
       "Etkinleştirildiğinde, başlatırken veya sıfırlarken PlayStation logosunu gösterir. (Bazı oyunları bozabilir).",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -356,7 +438,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_spu_reverb",
       "Ses Yankısı",
+      NULL,
       "Ses yankı efektini etkinleştirir veya devre dışı bırakır.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -365,6 +450,9 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_spu_interpolation",
       "Ses Enterpolasyonu",
+      NULL,
+      NULL,
+      NULL,
       NULL,
       {
          { NULL, NULL },
@@ -375,6 +463,9 @@ struct retro_core_option_definition option_defs_tr[] = {
       "pcsx_rearmed_pe2_fix",
       "Parasite Eve 2/Vandal Hearts 1/2 Düzeltmleri",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -384,6 +475,9 @@ struct retro_core_option_definition option_defs_tr[] = {
       "pcsx_rearmed_icache_emulation",
       "ICache Düzeltmleri",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -392,6 +486,9 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_inuyasha_fix",
       "InuYasha Sengoku Battle Düzeltmesi",
+      NULL,
+      NULL,
+      NULL,
       NULL,
       {
          { NULL, NULL },
@@ -404,6 +501,9 @@ struct retro_core_option_definition option_defs_tr[] = {
       "pcsx_rearmed_noxadecoding",
       "XA Kod Çözme",
       NULL,
+      NULL,
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -412,6 +512,9 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_nocdaudio",
       "CD Ses",
+      NULL,
+      NULL,
+      NULL,
       NULL,
       {
          { NULL, NULL },
@@ -423,7 +526,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_nosmccheck",
       "(Speed Hack) SMC Kontrollerini Devre Dışı Bırak",
+      NULL,
       "Yükleme sırasında çökmelere neden olabilir, hafıza kartını bozabilir.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -432,7 +538,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_gteregsunneeded",
       "(Speed Hack) GTE'nin Gereksiz Olduğunu Varsayın",
+      NULL,
       "Grafiksel bozukluklara neden olabilir.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -441,7 +550,10 @@ struct retro_core_option_definition option_defs_tr[] = {
    {
       "pcsx_rearmed_nogteflags",
       "(Speed Hack) GTE Bayraklarını Devredışı Bırakın",
+      NULL,
       "Grafiksel bozukluklara neden olur.",
+      NULL,
+      NULL,
       {
          { NULL, NULL },
       },
@@ -449,7 +561,12 @@ struct retro_core_option_definition option_defs_tr[] = {
    },
 #endif /* NEW_DYNAREC */
 
-   { NULL, NULL, NULL, {{0}}, NULL },
+   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL },
+};
+
+struct retro_core_options_v2 options_tr = {
+   option_cats_tr,
+   option_defs_tr
 };
 
 #ifdef __cplusplus

--- a/libretro-common/include/libretro.h
+++ b/libretro-common/include/libretro.h
@@ -283,6 +283,12 @@ enum retro_language
    RETRO_LANGUAGE_HEBREW              = 21,
    RETRO_LANGUAGE_ASTURIAN            = 22,
    RETRO_LANGUAGE_FINNISH             = 23,
+   RETRO_LANGUAGE_INDONESIAN          = 24,
+   RETRO_LANGUAGE_SWEDISH             = 25,
+   RETRO_LANGUAGE_UKRAINIAN           = 26,
+   RETRO_LANGUAGE_CZECH               = 27,
+   RETRO_LANGUAGE_CATALAN_VALENCIA    = 28,
+   RETRO_LANGUAGE_CATALAN             = 29,
    RETRO_LANGUAGE_LAST,
 
    /* Ensure sizeof(enum) == sizeof(int) */
@@ -1131,6 +1137,13 @@ enum retro_mod
                                             * retro_core_option_definition structs to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
                                             * This allows the core to additionally set option sublabel information
                                             * and/or provide localisation support.
+                                            *
+                                            * If version is >= 2, core options may instead be set by passing
+                                            * a retro_core_options_v2 struct to RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * or an array of retro_core_options_v2 structs to
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL. This allows the core
+                                            * to additionally set optional core option category information
+                                            * for frontends with core option category support.
                                             */
 
 #define RETRO_ENVIRONMENT_SET_CORE_OPTIONS 53
@@ -1172,7 +1185,7 @@ enum retro_mod
                                             * default value is NULL, the first entry in the
                                             * retro_core_option_definition::values array is treated as the default.
                                             *
-                                            * The number of possible options should be very limited,
+                                            * The number of possible option values should be very limited,
                                             * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
                                             * i.e. it should be feasible to cycle through options
                                             * without a keyboard.
@@ -1205,6 +1218,7 @@ enum retro_mod
                                             * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
                                             * returns an API version of >= 1.
                                             * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
                                             * This should be called the first time as early as
                                             * possible (ideally in retro_set_environment).
                                             * Afterwards it may be called again for the core to communicate
@@ -1376,6 +1390,373 @@ enum retro_mod
                                             * An eventual driver reinitialize will happen so that audio
                                             * callbacks happening after this call within the same retro_run()
                                             * call will target the newly initialized driver.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_FASTFORWARDING_OVERRIDE 64
+                                           /* const struct retro_fastforwarding_override * --
+                                            * Used by a libretro core to override the current
+                                            * fastforwarding mode of the frontend.
+                                            * If NULL is passed to this function, the frontend
+                                            * will return true if fastforwarding override
+                                            * functionality is supported (no change in
+                                            * fastforwarding state will occur in this case).
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE 65
+                                           /* const struct retro_system_content_info_override * --
+                                            * Allows an implementation to override 'global' content
+                                            * info parameters reported by retro_get_system_info().
+                                            * Overrides also affect subsystem content info parameters
+                                            * set via RETRO_ENVIRONMENT_SET_SUBSYSTEM_INFO.
+                                            * This function must be called inside retro_set_environment().
+                                            * If callback returns false, content info overrides
+                                            * are unsupported by the frontend, and will be ignored.
+                                            * If callback returns true, extended game info may be
+                                            * retrieved by calling RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+                                            * in retro_load_game() or retro_load_game_special().
+                                            *
+                                            * 'data' points to an array of retro_system_content_info_override
+                                            * structs terminated by a { NULL, false, false } element.
+                                            * If 'data' is NULL, no changes will be made to the frontend;
+                                            * a core may therefore pass NULL in order to test whether
+                                            * the RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE and
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT callbacks are supported
+                                            * by the frontend.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_system_content_info_override.
+                                            *
+                                            * Example:
+                                            *
+                                            * - struct retro_system_info:
+                                            * {
+                                            *    "My Core",                      // library_name
+                                            *    "v1.0",                         // library_version
+                                            *    "m3u|md|cue|iso|chd|sms|gg|sg", // valid_extensions
+                                            *    true,                           // need_fullpath
+                                            *    false                           // block_extract
+                                            * }
+                                            *
+                                            * - Array of struct retro_system_content_info_override:
+                                            * {
+                                            *    {
+                                            *       "md|sms|gg", // extensions
+                                            *       false,       // need_fullpath
+                                            *       true         // persistent_data
+                                            *    },
+                                            *    {
+                                            *       "sg",        // extensions
+                                            *       false,       // need_fullpath
+                                            *       false        // persistent_data
+                                            *    },
+                                            *    { NULL, false, false }
+                                            * }
+                                            *
+                                            * Result:
+                                            * - Files of type m3u, cue, iso, chd will not be
+                                            *   loaded by the frontend. Frontend will pass a
+                                            *   valid path to the core, and core will handle
+                                            *   loading internally
+                                            * - Files of type md, sms, gg will be loaded by
+                                            *   the frontend. A valid memory buffer will be
+                                            *   passed to the core. This memory buffer will
+                                            *   remain valid until retro_deinit() returns
+                                            * - Files of type sg will be loaded by the frontend.
+                                            *   A valid memory buffer will be passed to the core.
+                                            *   This memory buffer will remain valid until
+                                            *   retro_load_game() (or retro_load_game_special())
+                                            *   returns
+                                            *
+                                            * NOTE: If an extension is listed multiple times in
+                                            * an array of retro_system_content_info_override
+                                            * structs, only the first instance will be registered
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_GAME_INFO_EXT 66
+                                           /* const struct retro_game_info_ext ** --
+                                            * Allows an implementation to fetch extended game
+                                            * information, providing additional content path
+                                            * and memory buffer status details.
+                                            * This function may only be called inside
+                                            * retro_load_game() or retro_load_game_special().
+                                            * If callback returns false, extended game information
+                                            * is unsupported by the frontend. In this case, only
+                                            * regular retro_game_info will be available.
+                                            * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT is guaranteed
+                                            * to return true if RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+                                            * returns true.
+                                            *
+                                            * 'data' points to an array of retro_game_info_ext structs.
+                                            *
+                                            * For struct member descriptions, see the definition of
+                                            * struct retro_game_info_ext.
+                                            *
+                                            * - If function is called inside retro_load_game(),
+                                            *   the retro_game_info_ext array is guaranteed to
+                                            *   have a size of 1 - i.e. the returned pointer may
+                                            *   be used to access directly the members of the
+                                            *   first retro_game_info_ext struct, for example:
+                                            *
+                                            *      struct retro_game_info_ext *game_info_ext;
+                                            *      if (environ_cb(RETRO_ENVIRONMENT_GET_GAME_INFO_EXT, &game_info_ext))
+                                            *         printf("Content Directory: %s\n", game_info_ext->dir);
+                                            *
+                                            * - If the function is called inside retro_load_game_special(),
+                                            *   the retro_game_info_ext array is guaranteed to have a
+                                            *   size equal to the num_info argument passed to
+                                            *   retro_load_game_special()
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 67
+                                           /* const struct retro_core_options_v2 * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * 'data' points to a retro_core_options_v2 struct, containing
+                                            * of two pointers:
+                                            * - retro_core_options_v2::categories is an array of
+                                            *   retro_core_option_v2_category structs terminated by a
+                                            *   { NULL, NULL, NULL } element. If retro_core_options_v2::categories
+                                            *   is NULL, all core options will have no category and will be shown
+                                            *   at the top level of the frontend core option interface. If frontend
+                                            *   does not have core option category support, categories array will
+                                            *   be ignored.
+                                            * - retro_core_options_v2::definitions is an array of
+                                            *   retro_core_option_v2_definition structs terminated by a
+                                            *   { NULL, NULL, NULL, NULL, NULL, NULL, {{0}}, NULL }
+                                            *   element.
+                                            *
+                                            * >> retro_core_option_v2_category notes:
+                                            *
+                                            * - retro_core_option_v2_category::key should contain string
+                                            *   that uniquely identifies the core option category. Valid
+                                            *   key characters are [a-z, A-Z, 0-9, _, -]
+                                            *   Namespace collisions with other implementations' category
+                                            *   keys are permitted.
+                                            * - retro_core_option_v2_category::desc should contain a human
+                                            *   readable description of the category key.
+                                            * - retro_core_option_v2_category::info should contain any
+                                            *   additional human readable information text that a typical
+                                            *   user may need to understand the nature of the core option
+                                            *   category.
+                                            *
+                                            * Example entry:
+                                            * {
+                                            *     "advanced_settings",
+                                            *     "Advanced",
+                                            *     "Options affecting low-level emulation performance and accuracy."
+                                            * }
+                                            *
+                                            * >> retro_core_option_v2_definition notes:
+                                            *
+                                            * - retro_core_option_v2_definition::key should be namespaced to not
+                                            *   collide with other implementations' keys. e.g. A core called
+                                            *   'foo' should use keys named as 'foo_option'. Valid key characters
+                                            *   are [a-z, A-Z, 0-9, _, -].
+                                            * - retro_core_option_v2_definition::desc should contain a human readable
+                                            *   description of the key. Will be used when the frontend does not
+                                            *   have core option category support. Examples: "Aspect Ratio" or
+                                            *   "Video > Aspect Ratio".
+                                            * - retro_core_option_v2_definition::desc_categorized should contain a
+                                            *   human readable description of the key, which will be used when
+                                            *   frontend has core option category support. Example: "Aspect Ratio",
+                                            *   where associated retro_core_option_v2_category::desc is "Video".
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::desc will be used instead.
+                                            *   retro_core_option_v2_definition::desc_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::info should contain any additional
+                                            *   human readable information text that a typical user may need to
+                                            *   understand the functionality of the option.
+                                            * - retro_core_option_v2_definition::info_categorized should contain
+                                            *   any additional human readable information text that a typical user
+                                            *   may need to understand the functionality of the option, and will be
+                                            *   used when frontend has core option category support. This is provided
+                                            *   to accommodate the case where info text references an option by
+                                            *   name/desc, and the desc/desc_categorized text for that option differ.
+                                            *   If empty or NULL, the string specified by
+                                            *   retro_core_option_v2_definition::info will be used instead.
+                                            *   retro_core_option_v2_definition::info_categorized will be ignored
+                                            *   if retro_core_option_v2_definition::category_key is empty or NULL.
+                                            * - retro_core_option_v2_definition::category_key should contain a
+                                            *   category identifier (e.g. "video" or "audio") that will be
+                                            *   assigned to the core option if frontend has core option category
+                                            *   support. A categorized option will be shown in a subsection/
+                                            *   submenu of the frontend core option interface. If key is empty
+                                            *   or NULL, or if key does not match one of the
+                                            *   retro_core_option_v2_category::key values in the associated
+                                            *   retro_core_option_v2_category array, option will have no category
+                                            *   and will be shown at the top level of the frontend core option
+                                            *   interface.
+                                            * - retro_core_option_v2_definition::values is an array of
+                                            *   retro_core_option_value structs terminated by a { NULL, NULL }
+                                            *   element.
+                                            * --> retro_core_option_v2_definition::values[index].value is an
+                                            *     expected option value.
+                                            * --> retro_core_option_v2_definition::values[index].label is a
+                                            *     human readable label used when displaying the value on screen.
+                                            *     If NULL, the value itself is used.
+                                            * - retro_core_option_v2_definition::default_value is the default
+                                            *   core option setting. It must match one of the expected option
+                                            *   values in the retro_core_option_v2_definition::values array. If
+                                            *   it does not, or the default value is NULL, the first entry in the
+                                            *   retro_core_option_v2_definition::values array is treated as the
+                                            *   default.
+                                            *
+                                            * The number of possible option values should be very limited,
+                                            * and must be less than RETRO_NUM_CORE_OPTION_VALUES_MAX.
+                                            * i.e. it should be feasible to cycle through options
+                                            * without a keyboard.
+                                            *
+                                            * Example entries:
+                                            *
+                                            * - Uncategorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Speed hack coprocessor X",
+                                            *     NULL,
+                                            *     "Provides increased performance at the expense of reduced accuracy.",
+                                            *     NULL,
+                                            *     NULL,
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * - Categorized:
+                                            *
+                                            * {
+                                            *     "foo_option",
+                                            *     "Advanced > Speed hack coprocessor X",
+                                            *     "Speed hack coprocessor X",
+                                            *     "Setting 'Advanced > Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "Setting 'Speed hack coprocessor X' to 'true' or 'Turbo' provides increased performance at the expense of reduced accuracy",
+                                            *     "advanced_settings",
+                                            * 	  {
+                                            *         { "false",    NULL },
+                                            *         { "true",     NULL },
+                                            *         { "unstable", "Turbo (Unstable)" },
+                                            *         { NULL, NULL },
+                                            *     },
+                                            *     "false"
+                                            * }
+                                            *
+                                            * Only strings are operated on. The possible values will
+                                            * generally be displayed and stored as-is by the frontend.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL 68
+                                           /* const struct retro_core_options_v2_intl * --
+                                            * Allows an implementation to signal the environment
+                                            * which variables it might want to check for later using
+                                            * GET_VARIABLE.
+                                            * This allows the frontend to present these variables to
+                                            * a user dynamically.
+                                            * This should only be called if RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION
+                                            * returns an API version of >= 2.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_VARIABLES.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL.
+                                            * This should be called instead of RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2.
+                                            * This should be called the first time as early as
+                                            * possible (ideally in retro_set_environment).
+                                            * Afterwards it may be called again for the core to communicate
+                                            * updated options to the frontend, but the number of core
+                                            * options must not change from the number in the initial call.
+                                            * If RETRO_ENVIRONMENT_GET_CORE_OPTIONS_VERSION returns an API
+                                            * version of >= 2, this callback is guaranteed to succeed
+                                            * (i.e. callback return value does not indicate success)
+                                            * If callback returns true, frontend has core option category
+                                            * support.
+                                            * If callback returns false, frontend does not have core option
+                                            * category support.
+                                            *
+                                            * This is fundamentally the same as RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2,
+                                            * with the addition of localisation support. The description of the
+                                            * RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2 callback should be consulted
+                                            * for further details.
+                                            *
+                                            * 'data' points to a retro_core_options_v2_intl struct.
+                                            *
+                                            * - retro_core_options_v2_intl::us is a pointer to a
+                                            *   retro_core_options_v2 struct defining the US English
+                                            *   core options implementation. It must point to a valid struct.
+                                            *
+                                            * - retro_core_options_v2_intl::local is a pointer to a
+                                            *   retro_core_options_v2 struct defining core options for
+                                            *   the current frontend language. It may be NULL (in which case
+                                            *   retro_core_options_v2_intl::us is used by the frontend). Any items
+                                            *   missing from this struct will be read from
+                                            *   retro_core_options_v2_intl::us instead.
+                                            *
+                                            * NOTE: Default core option values are always taken from the
+                                            * retro_core_options_v2_intl::us struct. Any default values in
+                                            * the retro_core_options_v2_intl::local struct will be ignored.
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_CORE_OPTIONS_UPDATE_DISPLAY_CALLBACK 69
+                                           /* const struct retro_core_options_update_display_callback * --
+                                            * Allows a frontend to signal that a core must update
+                                            * the visibility of any dynamically hidden core options,
+                                            * and enables the frontend to detect visibility changes.
+                                            * Used by the frontend to update the menu display status
+                                            * of core options without requiring a call of retro_run().
+                                            * Must be called in retro_set_environment().
+                                            */
+
+#define RETRO_ENVIRONMENT_SET_VARIABLE 70
+                                           /* const struct retro_variable * --
+                                            * Allows an implementation to notify the frontend
+                                            * that a core option value has changed.
+                                            *
+                                            * retro_variable::key and retro_variable::value
+                                            * must match strings that have been set previously
+                                            * via one of the following:
+                                            *
+                                            * - RETRO_ENVIRONMENT_SET_VARIABLES
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL
+                                            *
+                                            * After changing a core option value via this
+                                            * callback, RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE
+                                            * will return true.
+                                            *
+                                            * If data is NULL, no changes will be registered
+                                            * and the callback will return true; an
+                                            * implementation may therefore pass NULL in order
+                                            * to test whether the callback is supported.
+                                            */
+
+#define RETRO_ENVIRONMENT_GET_THROTTLE_STATE (71 | RETRO_ENVIRONMENT_EXPERIMENTAL)
+                                           /* struct retro_throttle_state * --
+                                            * Allows an implementation to get details on the actual rate
+                                            * the frontend is attempting to call retro_run().
                                             */
 
 /* VFS functionality */
@@ -2781,6 +3162,213 @@ struct retro_system_info
    bool        block_extract;
 };
 
+/* Defines overrides which modify frontend handling of
+ * specific content file types.
+ * An array of retro_system_content_info_override is
+ * passed to RETRO_ENVIRONMENT_SET_CONTENT_INFO_OVERRIDE
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_system_content_info_override
+{
+   /* A list of file extensions for which the override
+    * should apply, delimited by a 'pipe' character
+    * (e.g. "md|sms|gg")
+    * Permitted file extensions are limited to those
+    * included in retro_system_info::valid_extensions
+    * and/or retro_subsystem_rom_info::valid_extensions */
+   const char *extensions;
+
+   /* Overrides the need_fullpath value set in
+    * retro_system_info and/or retro_subsystem_rom_info.
+    * To reiterate:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info::path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info::data and retro_game_info::size are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - retro_game_info::path may be NULL
+    *    - retro_game_info::data and retro_game_info::size are guaranteed
+    *      to be valid
+    *
+    * In addition:
+    *
+    * If need_fullpath is true and retro_load_game() is called:
+    *    - retro_game_info_ext::full_path is guaranteed to contain a valid
+    *      path to an existent file
+    *    - retro_game_info_ext::archive_path may be NULL
+    *    - retro_game_info_ext::archive_file may be NULL
+    *    - retro_game_info_ext::dir is guaranteed to contain a valid path
+    *      to the directory in which the content file exists
+    *    - retro_game_info_ext::name is guaranteed to contain the
+    *      basename of the content file, without extension
+    *    - retro_game_info_ext::ext is guaranteed to contain the
+    *      extension of the content file in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are invalid
+    *
+    * If need_fullpath is false and retro_load_game() is called:
+    *    - If retro_game_info_ext::file_in_archive is false:
+    *       - retro_game_info_ext::full_path is guaranteed to contain
+    *         a valid path to an existent file
+    *       - retro_game_info_ext::archive_path may be NULL
+    *       - retro_game_info_ext::archive_file may be NULL
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the content file exists
+    *       - retro_game_info_ext::name is guaranteed to contain the
+    *         basename of the content file, without extension
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file in lower case format
+    *    - If retro_game_info_ext::file_in_archive is true:
+    *       - retro_game_info_ext::full_path may be NULL
+    *       - retro_game_info_ext::archive_path is guaranteed to
+    *         contain a valid path to an existent compressed file
+    *         inside which the content file is located
+    *       - retro_game_info_ext::archive_file is guaranteed to
+    *         contain a valid path to an existent content file
+    *         inside the compressed file referred to by
+    *         retro_game_info_ext::archive_path
+    *            e.g. for a compressed file '/path/to/foo.zip'
+    *            containing 'bar.sfc'
+    *             > retro_game_info_ext::archive_path will be '/path/to/foo.zip'
+    *             > retro_game_info_ext::archive_file will be 'bar.sfc'
+    *       - retro_game_info_ext::dir is guaranteed to contain a
+    *         valid path to the directory in which the compressed file
+    *         (containing the content file) exists
+    *       - retro_game_info_ext::name is guaranteed to contain
+    *         EITHER
+    *         1) the basename of the compressed file (containing
+    *            the content file), without extension
+    *         OR
+    *         2) the basename of the content file inside the
+    *            compressed file, without extension
+    *         In either case, a core should consider 'name' to
+    *         be the canonical name/ID of the the content file
+    *       - retro_game_info_ext::ext is guaranteed to contain the
+    *         extension of the content file inside the compressed file,
+    *         in lower case format
+    *    - retro_game_info_ext::data and retro_game_info_ext::size are
+    *      guaranteed to be valid */
+   bool need_fullpath;
+
+   /* If need_fullpath is false, specifies whether the content
+    * data buffer available in retro_load_game() is 'persistent'
+    *
+    * If persistent_data is false and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid only until retro_load_game() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid only until retro_load_game() returns
+    *
+    * If persistent_data is true and retro_load_game() is called:
+    *    - retro_game_info::data and retro_game_info::size
+    *      are valid until retro_deinit() returns
+    *    - retro_game_info_ext::data and retro_game_info_ext::size
+    *      are valid until retro_deinit() returns */
+   bool persistent_data;
+};
+
+/* Similar to retro_game_info, but provides extended
+ * information about the source content file and
+ * game memory buffer status.
+ * And array of retro_game_info_ext is returned by
+ * RETRO_ENVIRONMENT_GET_GAME_INFO_EXT
+ * NOTE: In the following descriptions, references to
+ *       retro_load_game() may be replaced with
+ *       retro_load_game_special() */
+struct retro_game_info_ext
+{
+   /* - If file_in_archive is false, contains a valid
+    *   path to an existent content file (UTF-8 encoded)
+    * - If file_in_archive is true, may be NULL */
+   const char *full_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contains a valid path
+    *   to an existent compressed file inside which the
+    *   content file is located (UTF-8 encoded) */
+   const char *archive_path;
+
+   /* - If file_in_archive is false, may be NULL
+    * - If file_in_archive is true, contain a valid path
+    *   to an existent content file inside the compressed
+    *   file referred to by archive_path (UTF-8 encoded)
+    *      e.g. for a compressed file '/path/to/foo.zip'
+    *      containing 'bar.sfc'
+    *      > archive_path will be '/path/to/foo.zip'
+    *      > archive_file will be 'bar.sfc' */
+   const char *archive_file;
+
+   /* - If file_in_archive is false, contains a valid path
+    *   to the directory in which the content file exists
+    *   (UTF-8 encoded)
+    * - If file_in_archive is true, contains a valid path
+    *   to the directory in which the compressed file
+    *   (containing the content file) exists (UTF-8 encoded) */
+   const char *dir;
+
+   /* Contains the canonical name/ID of the content file
+    * (UTF-8 encoded). Intended for use when identifying
+    * 'complementary' content named after the loaded file -
+    * i.e. companion data of a different format (a CD image
+    * required by a ROM), texture packs, internally handled
+    * save files, etc.
+    * - If file_in_archive is false, contains the basename
+    *   of the content file, without extension
+    * - If file_in_archive is true, then string is
+    *   implementation specific. A frontend may choose to
+    *   set a name value of:
+    *   EITHER
+    *   1) the basename of the compressed file (containing
+    *      the content file), without extension
+    *   OR
+    *   2) the basename of the content file inside the
+    *      compressed file, without extension
+    *   RetroArch sets the 'name' value according to (1).
+    *   A frontend that supports routine loading of
+    *   content from archives containing multiple unrelated
+    *   content files may set the 'name' value according
+    *   to (2). */
+   const char *name;
+
+   /* - If file_in_archive is false, contains the extension
+    *   of the content file in lower case format
+    * - If file_in_archive is true, contains the extension
+    *   of the content file inside the compressed file,
+    *   in lower case format */
+   const char *ext;
+
+   /* String of implementation specific meta-data. */
+   const char *meta;
+
+   /* Memory buffer of loaded game content. Will be NULL:
+    * IF
+    * - retro_system_info::need_fullpath is true and
+    *   retro_system_content_info_override::need_fullpath
+    *   is unset
+    * OR
+    * - retro_system_content_info_override::need_fullpath
+    *   is true */
+   const void *data;
+
+   /* Size of game content memory buffer, in bytes */
+   size_t size;
+
+   /* True if loaded content file is inside a compressed
+    * archive */
+   bool file_in_archive;
+
+   /* - If data is NULL, value is unset/ignored
+    * - If data is non-NULL:
+    *   - If persistent_data is false, data and size are
+    *     valid only until retro_load_game() returns
+    *   - If persistent_data is true, data and size are
+    *     are valid until retro_deinit() returns */
+   bool persistent_data;
+};
+
 struct retro_game_geometry
 {
    unsigned base_width;    /* Nominal video width of game. */
@@ -2879,6 +3467,10 @@ struct retro_core_option_definition
    const char *default_value;
 };
 
+#ifdef __PS3__
+#undef local
+#endif
+
 struct retro_core_options_intl
 {
    /* Pointer to an array of retro_core_option_definition structs
@@ -2890,6 +3482,143 @@ struct retro_core_options_intl
     * - Implementation for current frontend language
     * - May be NULL */
    struct retro_core_option_definition *local;
+};
+
+struct retro_core_option_v2_category
+{
+   /* Variable uniquely identifying the
+    * option category. Valid key characters
+    * are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable category description
+    * > Used as category menu label when
+    *   frontend has core option category
+    *   support */
+   const char *desc;
+
+   /* Human-readable category information
+    * > Used as category menu sublabel when
+    *   frontend has core option category
+    *   support
+    * > Optional (may be NULL or an empty
+    *   string) */
+   const char *info;
+};
+
+struct retro_core_option_v2_definition
+{
+   /* Variable to query in RETRO_ENVIRONMENT_GET_VARIABLE.
+    * Valid key characters are [a-z, A-Z, 0-9, _, -] */
+   const char *key;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend does
+    *   not have core option category support
+    *   e.g. "Video > Aspect Ratio" */
+   const char *desc;
+
+   /* Human-readable core option description
+    * > Used as menu label when frontend has
+    *   core option category support
+    *   e.g. "Aspect Ratio", where associated
+    *   retro_core_option_v2_category::desc
+    *   is "Video"
+    * > If empty or NULL, the string specified by
+    *   desc will be used as the menu label
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *desc_categorized;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel */
+   const char *info;
+
+   /* Human-readable core option information
+    * > Used as menu sublabel when frontend
+    *   has core option category support
+    *   (e.g. may be required when info text
+    *   references an option by name/desc,
+    *   and the desc/desc_categorized text
+    *   for that option differ)
+    * > If empty or NULL, the string specified by
+    *   info will be used as the menu sublabel
+    * > Will be ignored (and may be set to NULL)
+    *   if category_key is empty or NULL */
+   const char *info_categorized;
+
+   /* Variable specifying category (e.g. "video",
+    * "audio") that will be assigned to the option
+    * if frontend has core option category support.
+    * > Categorized options will be displayed in a
+    *   subsection/submenu of the frontend core
+    *   option interface
+    * > Specified string must match one of the
+    *   retro_core_option_v2_category::key values
+    *   in the associated retro_core_option_v2_category
+    *   array; If no match is not found, specified
+    *   string will be considered as NULL
+    * > If specified string is empty or NULL, option will
+    *   have no category and will be shown at the top
+    *   level of the frontend core option interface */
+   const char *category_key;
+
+   /* Array of retro_core_option_value structs, terminated by NULL */
+   struct retro_core_option_value values[RETRO_NUM_CORE_OPTION_VALUES_MAX];
+
+   /* Default core option value. Must match one of the values
+    * in the retro_core_option_value array, otherwise will be
+    * ignored */
+   const char *default_value;
+};
+
+struct retro_core_options_v2
+{
+   /* Array of retro_core_option_v2_category structs,
+    * terminated by NULL
+    * > If NULL, all entries in definitions array
+    *   will have no category and will be shown at
+    *   the top level of the frontend core option
+    *   interface
+    * > Will be ignored if frontend does not have
+    *   core option category support */
+   struct retro_core_option_v2_category *categories;
+
+   /* Array of retro_core_option_v2_definition structs,
+    * terminated by NULL */
+   struct retro_core_option_v2_definition *definitions;
+};
+
+struct retro_core_options_v2_intl
+{
+   /* Pointer to a retro_core_options_v2 struct
+    * > US English implementation
+    * > Must point to a valid struct */
+   struct retro_core_options_v2 *us;
+
+   /* Pointer to a retro_core_options_v2 struct
+    * - Implementation for current frontend language
+    * - May be NULL */
+   struct retro_core_options_v2 *local;
+};
+
+/* Used by the frontend to monitor changes in core option
+ * visibility. May be called each time any core option
+ * value is set via the frontend.
+ * - On each invocation, the core must update the visibility
+ *   of any dynamically hidden options using the
+ *   RETRO_ENVIRONMENT_SET_CORE_OPTIONS_DISPLAY environment
+ *   callback.
+ * - On the first invocation, returns 'true' if the visibility
+ *   of any core option has changed since the last call of
+ *   retro_load_game() or retro_load_game_special().
+ * - On each subsequent invocation, returns 'true' if the
+ *   visibility of any core option has changed since the last
+ *   time the function was called. */
+typedef bool (RETRO_CALLCONV *retro_core_options_update_display_callback_t)(void);
+struct retro_core_options_update_display_callback
+{
+   retro_core_options_update_display_callback_t callback;
 };
 
 struct retro_game_info
@@ -2936,6 +3665,84 @@ struct retro_framebuffer
    unsigned memory_flags;           /* Flags telling core how the memory has been mapped.
                                        RETRO_MEMORY_TYPE_* flags.
                                        Set by frontend in GET_CURRENT_SOFTWARE_FRAMEBUFFER. */
+};
+
+/* Used by a libretro core to override the current
+ * fastforwarding mode of the frontend */
+struct retro_fastforwarding_override
+{
+   /* Specifies the runtime speed multiplier that
+    * will be applied when 'fastforward' is true.
+    * For example, a value of 5.0 when running 60 FPS
+    * content will cap the fast-forward rate at 300 FPS.
+    * Note that the target multiplier may not be achieved
+    * if the host hardware has insufficient processing
+    * power.
+    * Setting a value of 0.0 (or greater than 0.0 but
+    * less than 1.0) will result in an uncapped
+    * fast-forward rate (limited only by hardware
+    * capacity).
+    * If the value is negative, it will be ignored
+    * (i.e. the frontend will use a runtime speed
+    * multiplier of its own choosing) */
+   float ratio;
+
+   /* If true, fastforwarding mode will be enabled.
+    * If false, fastforwarding mode will be disabled. */
+   bool fastforward;
+
+   /* If true, and if supported by the frontend, an
+    * on-screen notification will be displayed while
+    * 'fastforward' is true.
+    * If false, and if supported by the frontend, any
+    * on-screen fast-forward notifications will be
+    * suppressed */
+   bool notification;
+
+   /* If true, the core will have sole control over
+    * when fastforwarding mode is enabled/disabled;
+    * the frontend will not be able to change the
+    * state set by 'fastforward' until either
+    * 'inhibit_toggle' is set to false, or the core
+    * is unloaded */
+   bool inhibit_toggle;
+};
+
+/* During normal operation. Rate will be equal to the core's internal FPS. */
+#define RETRO_THROTTLE_NONE              0
+
+/* While paused or stepping single frames. Rate will be 0. */
+#define RETRO_THROTTLE_FRAME_STEPPING    1
+
+/* During fast forwarding.
+ * Rate will be 0 if not specifically limited to a maximum speed. */
+#define RETRO_THROTTLE_FAST_FORWARD      2
+
+/* During slow motion. Rate will be less than the core's internal FPS. */
+#define RETRO_THROTTLE_SLOW_MOTION       3
+
+/* While rewinding recorded save states. Rate can vary depending on the rewind
+ * speed or be 0 if the frontend is not aiming for a specific rate. */
+#define RETRO_THROTTLE_REWINDING         4
+
+/* While vsync is active in the video driver and the target refresh rate is
+ * lower than the core's internal FPS. Rate is the target refresh rate. */
+#define RETRO_THROTTLE_VSYNC             5
+
+/* When the frontend does not throttle in any way. Rate will be 0.
+ * An example could be if no vsync or audio output is active. */
+#define RETRO_THROTTLE_UNBLOCKED         6
+
+struct retro_throttle_state
+{
+   /* The current throttling mode. Should be one of the values above. */
+   unsigned mode;
+
+   /* How many times per second the frontend aims to call retro_run.
+    * Depending on the mode, it can be 0 if there is no known fixed rate.
+    * This won't be accurate if the total processing time of the core and
+    * the frontend is longer than what is available for one frame. */
+   float rate;
 };
 
 /* Callbacks */


### PR DESCRIPTION
This PR updates the core options to v2 format. In addition:

- Core option categories have been added
- On frontends without category support, the various 'show/hide input/GPU plugin settings' options now apply in real time (without togging the quick menu)
- Missing option sublabels have been added
- Existing sublables have been clarified
- Options have been generally reordered/reorganised in more rational fashion...
- Three non-functional (and confusing) options have been removed: `pcsx_rearmed_gpu_peops_old_frame_skip`, `pcsx_rearmed_gpu_unai_ilace_force`, `pcsx_rearmed_gpu_unai_pixel_skip`