### PR TITLE
Fix Lightrec build on Windows and Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,8 @@ libpcsxcore/psxbios.o: CFLAGS += -Wno-nonnull
 # dynarec
 ifeq "$(DYNAREC)" "lightrec"
 CFLAGS += -Ideps/lightning/include -Ideps/lightrec -Iinclude/lightning -Iinclude/lightrec \
-		  -DLIGHTREC -DLIGHTREC_STATIC -DHAVE_MMAP
+		  -DLIGHTREC -DLIGHTREC_STATIC
+deps/lightning/lib/%.o: CFLAGS += -DHAVE_MMAP
 ifeq ($(LIGHTREC_CUSTOM_MAP),1)
 LDLIBS += -lrt
 OBJS += libpcsxcore/lightrec/mem.o

--- a/libpcsxcore/lightrec/mem.c
+++ b/libpcsxcore/lightrec/mem.c
@@ -25,6 +25,10 @@
 #define MAP_FIXED_NOREPLACE 0x100000
 #endif
 
+#ifndef MFD_HUGETLB
+#define MFD_HUGETLB 0x0004
+#endif
+
 static const uintptr_t supported_io_bases[] = {
 	0x0,
 	0x10000000,


### PR DESCRIPTION
Some distributions of Linux don't have the MFD_HUGETLB flag in
<linux/memfd.h>, probably because their kernel headers installed are too
old. In that case, we locally define MFD_HUGETLB to the value it should
have.

On Windows, the HAVE_MMAP macro set for GNU Lightning was also used in
libretro-common/vfs/vfs_implementation.c, causing build issues. Address
this problem by only defining HAVE_MMAP for Lightning source files.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>