### PR TITLE
Update GNU Lightning

### DIFF
--- a/deps/lightning/.gitrepo
+++ b/deps/lightning/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/pcercuei/gnu_lightning.git
 	branch = pcsx_rearmed
-	commit = 2a199e4d3cb250a76bd91f42eaf56f6233d34663
-	parent = db4140baf19c727fa1a705236130edfc6f363ce0
+	commit = 7fce9abb2a6bfc3967b4e5705794e617ed909402
+	parent = 94d482f4b7f5da2c5af7e3590b770261f907f185
 	method = merge
 	cmdver = 0.4.3

--- a/deps/lightning/lib/jit_size.c
+++ b/deps/lightning/lib/jit_size.c
@@ -105,7 +105,7 @@ _jit_get_size(jit_state_t *_jit)
     for (size = JIT_INSTR_MAX, node = _jitc->head; node; node = node->next)
 	size += _szs[node->code];
 
-    return ((size + 4095) & -4096);
+    return size;
 }
 #endif
 


### PR DESCRIPTION
Update GNU Lightning to the latest version on my repo, to get this fix: https://github.com/pcercuei/gnu_lightning/commit/7fce9abb2a6bfc3967b4e5705794e617ed909402

Without it, the code buffer will start overflowing after maybe 1.5 MiB of generated code, even though the code buffer is 8 MiB.