### PR TITLE
Rumble should only work with 'dualshock' device type

### DIFF
--- a/libpcsxcore/plugins.c
+++ b/libpcsxcore/plugins.c
@@ -793,8 +793,7 @@ unsigned char _PADpoll(int port, unsigned char value) {
 				//mem the vibration value for Large motor;
 				pad[port].Vib[1] = value;
 
-				if (in_type[port] == PSE_PAD_TYPE_STANDARD &&
-					in_type[port] == PSE_PAD_TYPE_NEGCON)
+				if (in_type[port] != PSE_PAD_TYPE_ANALOGPAD)
 					break;
 
 				//vibration


### PR DESCRIPTION
Noticed that in some games the controller will rumble even if 'standard' is selected as a device type. It's happening in Resident Evil - Director's Cut - Dual Shock Ver. when you shoot or push an object for example, I also noticed it when your health is low in Silent Hill.

Even the rumble core option says it should only work with 'dualshock' device type: https://github.com/libretro/pcsx_rearmed/blob/9723f27f9d28d90c8f54a9cd9e7203a87cc41b29/frontend/libretro_core_options.h#L769

So here's a little fix, idk if there's a better way to handle that but it seems to work properly.