### PR TITLE
Fix PCSX core and dfxvideo for big-endian systems

### DIFF
--- a/frontend/cspace.c
+++ b/frontend/cspace.c
@@ -15,21 +15,30 @@
  * in favor of NEON version or platform-specific conversion
  */
 
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define SWAP16(x) __builtin_bswap16(x)
+#define LE16TOHx2(x) ((SWAP16((x) >> 16) << 16) | SWAP16(x))
+#else
+#define LE16TOHx2(x) (x)
+#endif
+
 #ifndef __arm__
 
 void bgr555_to_rgb565(void *dst_, const void *src_, int bytes)
 {
-	const unsigned int *src = src_;
-	unsigned int *dst = dst_;
-	unsigned int p;
-	int x;
+    const unsigned int *src = src_;
+    unsigned int *dst = dst_;
+    unsigned int x, p, r, g, b;
 
-	for (x = 0; x < bytes / 4; x++) {
-		p = src[x];
-		p = ((p & 0x7c007c00) >> 10) | ((p & 0x03e003e0) << 1)
-			| ((p & 0x001f001f) << 11);
-		dst[x] = p;
-	}
+    for (x = 0; x < bytes / 4; x++) {
+        p = LE16TOHx2(src[x]);
+
+        r = (p & 0x001f001f) << 11;
+        g = (p & 0x03e003e0) << 1;
+        b = (p & 0x7c007c00) >> 10;
+
+        dst[x] = r | g | b;
+    }
 }
 
 #endif
@@ -71,8 +80,13 @@ void bgr888_to_rgb565(void *dst_, const void *src_, int bytes)
         r2 = src[3] & 0xf8;
         g2 = src[4] & 0xfc;
         b2 = src[5] & 0xf8;
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+        *dst = (r1 << 24) | (g1 << 19) | (b1 << 13) |
+               (r2 << 8) | (g2 << 3) | (b2 >> 3);
+#else
         *dst = (r2 << 24) | (g2 << 19) | (b2 << 13) |
                (r1 << 8) | (g1 << 3) | (b1 >> 3);
+#endif
     }
 }
 

--- a/libpcsxcore/cdriso.c
+++ b/libpcsxcore/cdriso.c
@@ -685,6 +685,7 @@ static int handlepbp(const char *isofile) {
 	off_t psisoimg_offs, cdimg_base;
 	unsigned int t, cd_length;
 	unsigned int offsettab[8];
+	unsigned int psar_offs, index_entry_size, index_entry_offset;
 	const char *ext = NULL;
 	int i, ret;
 
@@ -703,21 +704,23 @@ static int handlepbp(const char *isofile) {
 		goto fail_io;
 	}
 
-	ret = fseeko(cdHandle, pbp_hdr.psar_offs, SEEK_SET);
+	psar_offs = SWAP32(pbp_hdr.psar_offs);
+
+	ret = fseeko(cdHandle, psar_offs, SEEK_SET);
 	if (ret != 0) {
-		SysPrintf("failed to seek to %x\n", pbp_hdr.psar_offs);
+		SysPrintf("failed to seek to %x\n", psar_offs);
 		goto fail_io;
 	}
 
-	psisoimg_offs = pbp_hdr.psar_offs;
+	psisoimg_offs = psar_offs;
 	if (fread(psar_sig, 1, sizeof(psar_sig), cdHandle) != sizeof(psar_sig))
 		goto fail_io;
 	psar_sig[10] = 0;
 	if (strcmp(psar_sig, "PSTITLEIMG") == 0) {
 		// multidisk image?
-		ret = fseeko(cdHandle, pbp_hdr.psar_offs + 0x200, SEEK_SET);
+		ret = fseeko(cdHandle, psar_offs + 0x200, SEEK_SET);
 		if (ret != 0) {
-			SysPrintf("failed to seek to %x\n", pbp_hdr.psar_offs + 0x200);
+			SysPrintf("failed to seek to %x\n", psar_offs + 0x200);
 			goto fail_io;
 		}
 
@@ -739,7 +742,7 @@ static int handlepbp(const char *isofile) {
 		if (cdrIsoMultidiskSelect >= cdrIsoMultidiskCount)
 			cdrIsoMultidiskSelect = 0;
 
-		psisoimg_offs += offsettab[cdrIsoMultidiskSelect];
+		psisoimg_offs += SWAP32(offsettab[cdrIsoMultidiskSelect]);
 
 		ret = fseeko(cdHandle, psisoimg_offs, SEEK_SET);
 		if (ret != 0) {
@@ -823,12 +826,15 @@ static int handlepbp(const char *isofile) {
 			goto fail_index;
 		}
 
-		if (index_entry.size == 0)
+		index_entry_size = SWAP32(index_entry.size);
+		index_entry_offset = SWAP32(index_entry.offset);
+
+		if (index_entry_size == 0)
 			break;
 
-		compr_img->index_table[i] = cdimg_base + index_entry.offset;
+		compr_img->index_table[i] = cdimg_base + index_entry_offset;
 	}
-	compr_img->index_table[i] = cdimg_base + index_entry.offset + index_entry.size;
+	compr_img->index_table[i] = cdimg_base + index_entry_offset + index_entry_size;
 
 	return 0;
 

--- a/libpcsxcore/gpu.h
+++ b/libpcsxcore/gpu.h
@@ -38,8 +38,8 @@
 #define PSXGPU_TIMING_BITS (PSXGPU_LCF | PSXGPU_nBUSY)
 
 #define gpuSyncPluginSR() { \
-	HW_GPU_STATUS &= PSXGPU_TIMING_BITS; \
-	HW_GPU_STATUS |= GPU_readStatus() & ~PSXGPU_TIMING_BITS; \
+	HW_GPU_STATUS &= SWAP32(PSXGPU_TIMING_BITS); \
+	HW_GPU_STATUS |= SWAP32(GPU_readStatus() & ~PSXGPU_TIMING_BITS); \
 }
 
 #endif /* __GPU_H__ */

--- a/libpcsxcore/misc.c
+++ b/libpcsxcore/misc.c
@@ -724,7 +724,7 @@ int LoadState(const char *file) {
 	GPU_freeze(0, gpufP);
 	free(gpufP);
 	if (HW_GPU_STATUS == 0)
-		HW_GPU_STATUS = GPU_readStatus();
+		HW_GPU_STATUS = SWAP32(GPU_readStatus());
 
 	// spu
 	SaveFuncs.read(f, &Size, 4);

--- a/libpcsxcore/misc.c
+++ b/libpcsxcore/misc.c
@@ -61,7 +61,7 @@ void mmssdd( char *b, char *p )
 #if defined(__arm__)
 	unsigned char *u = (void *)b;
 	int block = (u[3] << 24) | (u[2] << 16) | (u[1] << 8) | u[0];
-#elif defined(__BIGENDIAN__)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 	int block = (b[0] & 0xff) | ((b[1] & 0xff) << 8) | ((b[2] & 0xff) << 16) | (b[3] << 24);
 #else
 	int block = *((int*)b);

--- a/libpcsxcore/misc.c
+++ b/libpcsxcore/misc.c
@@ -58,14 +58,7 @@ struct iso_directory_record {
 void mmssdd( char *b, char *p )
 {
 	int m, s, d;
-#if defined(__arm__)
-	unsigned char *u = (void *)b;
-	int block = (u[3] << 24) | (u[2] << 16) | (u[1] << 8) | u[0];
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	int block = (b[0] & 0xff) | ((b[1] & 0xff) << 8) | ((b[2] & 0xff) << 16) | (b[3] << 24);
-#else
-	int block = *((int*)b);
-#endif
+	int block = SWAP32(*((uint32_t*) b));
 
 	block += 150;
 	m = block / 4500;			// minutes

--- a/libpcsxcore/psxcounters.c
+++ b/libpcsxcore/psxcounters.c
@@ -327,7 +327,7 @@ void psxRcntUpdate()
         // VSync irq.
         if( hSyncCount == VBlankStart )
         {
-            HW_GPU_STATUS &= ~PSXGPU_LCF;
+            HW_GPU_STATUS &= SWAP32(~PSXGPU_LCF);
             GPU_vBlank( 1, 0 );
             setIrq( 0x01 );
 
@@ -347,9 +347,9 @@ void psxRcntUpdate()
             frame_counter++;
 
             gpuSyncPluginSR();
-            if( (HW_GPU_STATUS & PSXGPU_ILACE_BITS) == PSXGPU_ILACE_BITS )
-                HW_GPU_STATUS |= frame_counter << 31;
-            GPU_vBlank( 0, HW_GPU_STATUS >> 31 );
+            if ((HW_GPU_STATUS & SWAP32(PSXGPU_ILACE_BITS)) == SWAP32(PSXGPU_ILACE_BITS))
+                HW_GPU_STATUS |= SWAP32(frame_counter << 31);
+            GPU_vBlank(0, SWAP32(HW_GPU_STATUS) >> 31);
         }
 
         // Schedule next call, in hsyncs

--- a/libpcsxcore/psxdma.c
+++ b/libpcsxcore/psxdma.c
@@ -184,7 +184,7 @@ void psxDma2(u32 madr, u32 bcr, u32 chcr) { // GPU
 			size = GPU_dmaChain((u32 *)psxM, madr & 0x1fffff);
 			if ((int)size <= 0)
 				size = gpuDmaChainSize(madr);
-			HW_GPU_STATUS &= ~PSXGPU_nBUSY;
+			HW_GPU_STATUS &= SWAP32(~PSXGPU_nBUSY);
 
 			// we don't emulate progress, just busy flag and end irq,
 			// so pretend we're already at the last block
@@ -216,7 +216,7 @@ void gpuInterrupt() {
 		HW_DMA2_CHCR &= SWAP32(~0x01000000);
 		DMA_INTERRUPT(2);
 	}
-	HW_GPU_STATUS |= PSXGPU_nBUSY; // GPU no longer busy
+	HW_GPU_STATUS |= SWAP32(PSXGPU_nBUSY); // GPU no longer busy
 }
 
 void psxDma6(u32 madr, u32 bcr, u32 chcr) {
@@ -244,7 +244,7 @@ void psxDma6(u32 madr, u32 bcr, u32 chcr) {
 			*mem-- = SWAP32((madr - 4) & 0xffffff);
 			madr -= 4;
 		}
-		mem++; *mem = 0xffffff;
+		*++mem = SWAP32(0xffffff);
 
 		//GPUOTCDMA_INT(size);
 		// halted

--- a/libpcsxcore/psxhw.c
+++ b/libpcsxcore/psxhw.c
@@ -38,7 +38,7 @@ void psxHwReset() {
 	mdecInit(); // initialize mdec decoder
 	cdrReset();
 	psxRcntInit();
-	HW_GPU_STATUS = 0x14802000;
+	HW_GPU_STATUS = SWAP32(0x14802000);
 }
 
 u8 psxHwRead8(u32 add) {
@@ -248,8 +248,8 @@ u32 psxHwRead32(u32 add) {
 			return hard;
 		case 0x1f801814:
 			gpuSyncPluginSR();
-			hard = HW_GPU_STATUS;
-			if (hSyncCount < 240 && (HW_GPU_STATUS & PSXGPU_ILACE_BITS) != PSXGPU_ILACE_BITS)
+			hard = SWAP32(HW_GPU_STATUS);
+			if (hSyncCount < 240 && (hard & PSXGPU_ILACE_BITS) != PSXGPU_ILACE_BITS)
 				hard |= PSXGPU_LCF & (psxRegs.cycle << 20);
 #ifdef PSXHW_LOG
 			PSXHW_LOG("GPU STATUS 32bit read %x\n", hard);
@@ -446,7 +446,7 @@ void psxHwWrite16(u32 add, u16 value) {
 			PSXHW_LOG("IMASK 16bit write %x\n", value);
 #endif
 			psxHu16ref(0x1074) = SWAPu16(value);
-			if (psxHu16ref(0x1070) & value)
+			if (psxHu16ref(0x1070) & SWAPu16(value))
 				new_dyna_set_event(PSXINT_NEWDRC_CHECK, 1);
 			return;
 
@@ -560,7 +560,7 @@ void psxHwWrite32(u32 add, u32 value) {
 			PSXHW_LOG("IMASK 32bit write %x\n", value);
 #endif
 			psxHu32ref(0x1074) = SWAPu32(value);
-			if (psxHu32ref(0x1070) & value)
+			if (psxHu32ref(0x1070) & SWAPu32(value))
 				new_dyna_set_event(PSXINT_NEWDRC_CHECK, 1);
 			return;
 

--- a/libpcsxcore/psxmem.h
+++ b/libpcsxcore/psxmem.h
@@ -26,7 +26,7 @@ extern "C" {
 
 #include "psxcommon.h"
 
-#if defined(__BIGENDIAN__)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
 #define _SWAP16(b) ((((unsigned char *)&(b))[0] & 0xff) | (((unsigned char *)&(b))[1] & 0xff) << 8)
 #define _SWAP32(b) ((((unsigned char *)&(b))[0] & 0xff) | ((((unsigned char *)&(b))[1] & 0xff) << 8) | ((((unsigned char *)&(b))[2] & 0xff) << 16) | (((unsigned char *)&(b))[3] << 24))

--- a/libpcsxcore/psxmem.h
+++ b/libpcsxcore/psxmem.h
@@ -28,11 +28,8 @@ extern "C" {
 
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
-#define _SWAP16(b) ((((unsigned char *)&(b))[0] & 0xff) | (((unsigned char *)&(b))[1] & 0xff) << 8)
-#define _SWAP32(b) ((((unsigned char *)&(b))[0] & 0xff) | ((((unsigned char *)&(b))[1] & 0xff) << 8) | ((((unsigned char *)&(b))[2] & 0xff) << 16) | (((unsigned char *)&(b))[3] << 24))
-
-#define SWAP16(v) ((((v) & 0xff00) >> 8) +(((v) & 0xff) << 8))
-#define SWAP32(v) ((((v) & 0xff000000ul) >> 24) + (((v) & 0xff0000ul) >> 8) + (((v) & 0xff00ul)<<8) +(((v) & 0xfful) << 24))
+#define SWAP16(v) __builtin_bswap16(v)
+#define SWAP32(v) __builtin_bswap32(v)
 #define SWAPu32(v) SWAP32((u32)(v))
 #define SWAPs32(v) SWAP32((s32)(v))
 

--- a/libpcsxcore/r3000a.h
+++ b/libpcsxcore/r3000a.h
@@ -51,7 +51,7 @@ extern R3000Acpu psxInt;
 extern R3000Acpu psxRec;
 
 typedef union {
-#if defined(__BIGENDIAN__)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 	struct { u8 h3, h2, h, l; } b;
 	struct { s8 h3, h2, h, l; } sb;
 	struct { u16 h, l; } w;
@@ -222,7 +222,7 @@ void new_dyna_freeze(void *f, int mode);
 	} \
 }
 
-#if defined(__BIGENDIAN__)
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
 #define _i32(x) *(s32 *)&x
 #define _u32(x) x

--- a/plugins/dfxvideo/draw.c
+++ b/plugins/dfxvideo/draw.c
@@ -1053,7 +1053,7 @@ void CreateDisplay(void)
 			//backup YUV mode
 			//hmm, should I bother check guid == 55595659-0000-0010-8000-00aa00389b71?
 			//and check byte order?   fo[j].byte_order == LSBFirst
-#ifdef __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 			if ( fo[j].type == XvYUV && fo[j].bits_per_pixel == 16 && fo[j].format == XvPacked && strncmp("YUYV", fo[j].component_order, 5) == 0 )
 #else
 			if ( fo[j].type == XvYUV && fo[j].bits_per_pixel == 16 && fo[j].format == XvPacked && strncmp("UYVY", fo[j].component_order, 5) == 0 )
@@ -1473,7 +1473,7 @@ void BlitToYUV(unsigned char * surf,int32_t x,int32_t y)
        U = min(abs(R * -1214 + G * -2384 + B * 3598 + 4096 + 1048576) >> 13, 240);
        V = min(abs(R * 3598 + G * -3013 + B * -585 + 4096 + 1048576) >> 13, 240);
 
-#ifdef __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
        destpix[row] = Y << 24 | U << 16 | Y << 8 | V;
 #else
        destpix[row] = Y << 24 | V << 16 | Y << 8 | U;
@@ -1500,7 +1500,7 @@ void BlitToYUV(unsigned char * surf,int32_t x,int32_t y)
        U = min(abs(R * -1214 + G * -2384 + B * 3598 + 4096 + 1048576) >> 13, 240);
        V = min(abs(R * 3598 + G * -3013 + B * -585 + 4096 + 1048576) >> 13, 240);
 
-#ifdef __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
        destpix[row] = Y << 24 | U << 16 | Y << 8 | V;
 #else
        destpix[row] = Y << 24 | V << 16 | Y << 8 | U;
@@ -1534,7 +1534,7 @@ void RGB2YUV(uint32_t *s, int width, int height, uint32_t *d)
 
 			Y2 = min(abs(R * 2104 + G * 4130 + B * 802 + 4096 + 131072) >> 13, 235);
 
-#ifdef __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 			*d = V | Y2 << 8 | U << 16 | Y1 << 24;
 #else
 			*d = U | Y1 << 8 | V << 16 | Y2 << 24;

--- a/plugins/dfxvideo/gpu.c
+++ b/plugins/dfxvideo/gpu.c
@@ -985,7 +985,7 @@ ENDVRAM:
          if((gpuDataC==254 && gpuDataP>=3) ||
             (gpuDataC==255 && gpuDataP>=4 && !(gpuDataP&1)))
           {
-           if((gpuDataM[gpuDataP] & 0xF000F000) == 0x50005000)
+           if((gpuDataM[gpuDataP] & HOST2LE32(0xF000F000)) == HOST2LE32(0x50005000))
             gpuDataP=gpuDataC-1;
           }
         }

--- a/plugins/dfxvideo/gpu.h
+++ b/plugins/dfxvideo/gpu.h
@@ -69,8 +69,8 @@
 
 // byteswappings
 
-#define SWAP16(x) ({ uint16_t y=(x); (((y)>>8 & 0xff) | ((y)<<8 & 0xff00)); })
-#define SWAP32(x) ({ uint32_t y=(x); (((y)>>24 & 0xfful) | ((y)>>8 & 0xff00ul) | ((y)<<8 & 0xff0000ul) | ((y)<<24 & 0xff000000ul)); })
+#define SWAP16(x) __builtin_bswap16(x)
+#define SWAP32(x) __builtin_bswap32(x)
 
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
@@ -107,7 +107,7 @@
 #define GETLE32_(X) LE2HOST32(*(uint32_t *)X)
 #define GETLE16D(X) ({uint32_t val = GETLE32(X); (val<<16 | val >> 16);})
 #define PUTLE16(X, Y) do{*((uint16_t *)X)=HOST2LE16((uint16_t)Y);}while(0)
-#define PUTLE32_(X, Y) do{*((uint32_t *)X)=HOST2LE16((uint32_t)Y);}while(0)
+#define PUTLE32_(X, Y) do{*((uint32_t *)X)=HOST2LE32((uint32_t)Y);}while(0)
 #ifdef __arm__
 #define GETLE32(X) (*(uint16_t *)(X)|(((uint16_t *)(X))[1]<<16))
 #define PUTLE32(X, Y) do{uint16_t *p_=(uint16_t *)(X);uint32_t y_=Y;p_[0]=y_;p_[1]=y_>>16;}while(0)

--- a/plugins/dfxvideo/gpu.h
+++ b/plugins/dfxvideo/gpu.h
@@ -72,7 +72,7 @@
 #define SWAP16(x) ({ uint16_t y=(x); (((y)>>8 & 0xff) | ((y)<<8 & 0xff00)); })
 #define SWAP32(x) ({ uint32_t y=(x); (((y)>>24 & 0xfful) | ((y)>>8 & 0xff00ul) | ((y)<<8 & 0xff0000ul) | ((y)<<24 & 0xff000000ul)); })
 
-#ifdef __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
 // big endian config
 #define HOST2LE32(x) SWAP32(x)
@@ -251,18 +251,12 @@ extern int32_t           drawH;
 #define KEY_BADTEXTURES   128
 #define KEY_CHECKTHISOUT  256
 
-#if !defined(__BIG_ENDIAN__) || defined(__x86_64__) || defined(__i386__)
-#ifndef __LITTLE_ENDIAN__
-#define __LITTLE_ENDIAN__
-#endif
-#endif
-
-#ifdef __LITTLE_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define RED(x) (x & 0xff)
 #define BLUE(x) ((x>>16) & 0xff)
 #define GREEN(x) ((x>>8) & 0xff)
 #define COLOR(x) (x & 0xffffff)
-#elif defined __BIG_ENDIAN__
+#else
 #define RED(x) ((x>>24) & 0xff)
 #define BLUE(x) ((x>>8) & 0xff)
 #define GREEN(x) ((x>>16) & 0xff)

--- a/plugins/dfxvideo/gpulib_if.c
+++ b/plugins/dfxvideo/gpulib_if.c
@@ -56,7 +56,7 @@
 #define SWAP16(x) ({ uint16_t y=(x); (((y)>>8 & 0xff) | ((y)<<8 & 0xff00)); })
 #define SWAP32(x) ({ uint32_t y=(x); (((y)>>24 & 0xfful) | ((y)>>8 & 0xff00ul) | ((y)<<8 & 0xff0000ul) | ((y)<<24 & 0xff000000ul)); })
 
-#ifdef __BIG_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
 // big endian config
 #define HOST2LE32(x) SWAP32(x)
@@ -235,18 +235,12 @@ extern int32_t           drawH;
 #define KEY_BADTEXTURES   128
 #define KEY_CHECKTHISOUT  256
 
-#if !defined(__BIG_ENDIAN__) || defined(__x86_64__) || defined(__i386__)
-#ifndef __LITTLE_ENDIAN__
-#define __LITTLE_ENDIAN__
-#endif
-#endif
-
-#ifdef __LITTLE_ENDIAN__
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define RED(x) (x & 0xff)
 #define BLUE(x) ((x>>16) & 0xff)
 #define GREEN(x) ((x>>8) & 0xff)
 #define COLOR(x) (x & 0xffffff)
-#elif defined __BIG_ENDIAN__
+#else
 #define RED(x) ((x>>24) & 0xff)
 #define BLUE(x) ((x>>8) & 0xff)
 #define GREEN(x) ((x>>16) & 0xff)

--- a/plugins/dfxvideo/gpulib_if.c
+++ b/plugins/dfxvideo/gpulib_if.c
@@ -53,8 +53,8 @@
 
 // byteswappings
 
-#define SWAP16(x) ({ uint16_t y=(x); (((y)>>8 & 0xff) | ((y)<<8 & 0xff00)); })
-#define SWAP32(x) ({ uint32_t y=(x); (((y)>>24 & 0xfful) | ((y)>>8 & 0xff00ul) | ((y)<<8 & 0xff0000ul) | ((y)<<24 & 0xff000000ul)); })
+#define SWAP16(x) __builtin_bswap16(x)
+#define SWAP32(x) __builtin_bswap32(x)
 
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
 
@@ -91,7 +91,7 @@
 #define GETLE32_(X) LE2HOST32(*(uint32_t *)X)
 #define GETLE16D(X) ({uint32_t val = GETLE32(X); (val<<16 | val >> 16);})
 #define PUTLE16(X, Y) do{*((uint16_t *)X)=HOST2LE16((uint16_t)Y);}while(0)
-#define PUTLE32_(X, Y) do{*((uint32_t *)X)=HOST2LE16((uint32_t)Y);}while(0)
+#define PUTLE32_(X, Y) do{*((uint32_t *)X)=HOST2LE32((uint32_t)Y);}while(0)
 #ifdef __arm__
 #define GETLE32(X) (*(uint16_t *)(X)|(((uint16_t *)(X))[1]<<16))
 #define PUTLE32(X, Y) do{uint16_t *p_=(uint16_t *)(X);uint32_t y_=Y;p_[0]=y_;p_[1]=y_>>16;}while(0)
@@ -327,7 +327,7 @@ int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
 
   for (; list < list_end; list += 1 + len)
   {
-    cmd = *list >> 24;
+    cmd = GETLE32(list) >> 24;
     len = cmd_lengths[cmd];
     if (list + 1 + len > list_end) {
       cmd = -1;
@@ -338,7 +338,7 @@ int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
     if (cmd == 0xa0 || cmd == 0xc0)
       break; // image i/o, forward to upper layer
     else if ((cmd & 0xf8) == 0xe0)
-      gpu.ex_regs[cmd & 7] = list[0];
+      gpu.ex_regs[cmd & 7] = GETLE32(list);
 #endif
 
     primTableJ[cmd]((void *)list);
@@ -357,7 +357,7 @@ int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
             goto breakloop;
           }
 
-          if((*list_position & 0xf000f000) == 0x50005000)
+          if((*list_position & HOST2LE32(0xf000f000)) == HOST2LE32(0x50005000))
             break;
 
           list_position++;
@@ -380,7 +380,7 @@ int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
             goto breakloop;
           }
 
-          if((*list_position & 0xf000f000) == 0x50005000)
+          if((*list_position & HOST2LE32(0xf000f000)) == HOST2LE32(0x50005000))
             break;
 
           list_position += 2;
@@ -395,8 +395,8 @@ int do_cmd_list(uint32_t *list, int list_len, int *last_cmd)
       case 0xA0:          //  sys -> vid
       {
         short *slist = (void *)list;
-        u32 load_width = slist[4];
-        u32 load_height = slist[5];
+        u32 load_width = LE2HOST32(slist[4]);
+        u32 load_height = LE2HOST32(slist[5]);
         u32 load_size = load_width * load_height;
 
         len += load_size / 2;

--- a/plugins/dfxvideo/prim.c
+++ b/plugins/dfxvideo/prim.c
@@ -1240,7 +1240,7 @@ static void primLineGEx(unsigned char *baseAddr)
    sly1=(short)(((int)sly1<<SIGNSHIFT)>>SIGNSHIFT);
   }
 
- lc1 = gpuData[0] & 0xffffff;
+ lc1 = GETLE32(&gpuData[0]) & 0xffffff;
 
  DrawSemiTrans = (SEMITRANSBIT(GETLE32(&gpuData[0]))) ? TRUE : FALSE;
 

--- a/plugins/dfxvideo/soft.c
+++ b/plugins/dfxvideo/soft.c
@@ -292,7 +292,7 @@ static inline void GetShadeTransCol32(uint32_t * pdest,uint32_t color)
     {
      int32_t sr,sb,sg,src,sbc,sgc,c;
      src=XCOL1(color);sbc=XCOL2(color);sgc=XCOL3(color);
-     c=GETLE32(pdest)>>16;
+     c=HIWORD(GETLE32(pdest));
      sr=(XCOL1(c))-src;   if(sr&0x8000) sr=0;
      sb=(XCOL2(c))-sbc;  if(sb&0x8000) sb=0;
      sg=(XCOL3(c))-sgc; if(sg&0x8000) sg=0;
@@ -327,8 +327,8 @@ static inline void GetShadeTransCol32(uint32_t * pdest,uint32_t color)
     {
      uint32_t ma=GETLE32(pdest);
      PUTLE32(pdest, (X32PSXCOL(r,g,b))|lSetMask);//0x80008000;
-     if(ma&0x80000000) PUTLE32(pdest, (ma&0xFFFF0000)|(*pdest&0xFFFF));
-     if(ma&0x00008000) PUTLE32(pdest, (ma&0xFFFF)    |(*pdest&0xFFFF0000));
+     if(ma&0x80000000) PUTLE32(pdest, (ma&0xFFFF0000)|(GETLE32(pdest)&0xFFFF));
+     if(ma&0x00008000) PUTLE32(pdest, (ma&0xFFFF)    |(GETLE32(pdest)&0xFFFF0000));
      return;
     }
    PUTLE32(pdest, (X32PSXCOL(r,g,b))|lSetMask);//0x80008000;
@@ -950,7 +950,7 @@ static void FillSoftwareAreaTrans(short x0,short y0,short x1, // FILL AREA TRANS
   {
    static int iCheat=0;
    col+=iCheat;
-   if(iCheat==1) iCheat=0; else iCheat=1;
+   iCheat ^= 1;
   }
 
 
@@ -971,7 +971,7 @@ static void FillSoftwareAreaTrans(short x0,short y0,short x1, // FILL AREA TRANS
   {
    uint32_t *DSTPtr;
    unsigned short LineOffset;
-   uint32_t lcol=lSetMask|(((uint32_t)(col))<<16)|col;
+   uint32_t lcol = HOST2LE32(lSetMask | (((uint32_t)(col)) << 16) | col);
    dx>>=1;
    DSTPtr = (uint32_t *)(psxVuw + (1024*y0) + x0);
    LineOffset = 512 - dx;
@@ -980,7 +980,7 @@ static void FillSoftwareAreaTrans(short x0,short y0,short x1, // FILL AREA TRANS
     {
      for(i=0;i<dy;i++)
       {
-       for(j=0;j<dx;j++) { PUTLE32(DSTPtr, lcol); DSTPtr++; }
+       for(j=0;j<dx;j++) { *DSTPtr++ = lcol; }
        DSTPtr += LineOffset;
       }
     }
@@ -1035,14 +1035,14 @@ static void FillSoftwareArea(short x0,short y0,short x1,      // FILL AREA (BLK 
   {
    uint32_t *DSTPtr;
    unsigned short LineOffset;
-   uint32_t lcol=(((int32_t)col)<<16)|col;
+   uint32_t lcol = HOST2LE32((((uint32_t)(col)) << 16) | col);
    dx>>=1;
    DSTPtr = (uint32_t *)(psxVuw + (1024*y0) + x0);
    LineOffset = 512 - dx;
 
    for(i=0;i<dy;i++)
     {
-     for(j=0;j<dx;j++) { PUTLE32(DSTPtr, lcol); DSTPtr++; }
+     for(j=0;j<dx;j++) { *DSTPtr++ = lcol; }
      DSTPtr += LineOffset;
     } 
   }

--- a/plugins/gpulib/gpu.c
+++ b/plugins/gpulib/gpu.c
@@ -438,7 +438,7 @@ static void start_vram_transfer(uint32_t pos_word, uint32_t size_word, int is_re
   if (is_read) {
     gpu.status |= PSX_GPU_STATUS_IMG;
     // XXX: wrong for width 1
-    memcpy(&gpu.gp0, VRAM_MEM_XY(gpu.dma.x, gpu.dma.y), 4);
+    gpu.gp0 = LE32TOH(*(uint32_t *) VRAM_MEM_XY(gpu.dma.x, gpu.dma.y));
     gpu.state.last_vram_read_frame = *gpu.state.frame_count;
   }
 
@@ -690,8 +690,11 @@ uint32_t GPUreadData(void)
     flush_cmd_buffer();
 
   ret = gpu.gp0;
-  if (gpu.dma.h)
+  if (gpu.dma.h) {
+    ret = HTOLE32(ret);
     do_vram_io(&ret, 1, 1);
+    ret = LE32TOH(ret);
+  }
 
   log_io("gpu_read %08x\n", ret);
   return ret;

--- a/plugins/gpulib/gpu.h
+++ b/plugins/gpulib/gpu.h
@@ -19,37 +19,21 @@ extern "C" {
 
 #define CMD_BUFFER_LEN          1024
 
+#define BIT(x) (1 << (x))
+
+#define PSX_GPU_STATUS_DHEIGHT		BIT(19)
+#define PSX_GPU_STATUS_RGB24		BIT(21)
+#define PSX_GPU_STATUS_INTERLACE	BIT(22)
+#define PSX_GPU_STATUS_BLANKING		BIT(23)
+#define PSX_GPU_STATUS_IMG			BIT(27)
+#define PSX_GPU_STATUS_DMA(x)		((x) << 29)
+#define PSX_GPU_STATUS_DMA_MASK		(BIT(29) | BIT(30))
+
 struct psx_gpu {
   uint32_t cmd_buffer[CMD_BUFFER_LEN];
   uint32_t regs[16];
   uint16_t *vram;
-  union {
-    uint32_t reg;
-    struct {
-      uint32_t tx:4;        //  0 texture page
-      uint32_t ty:1;
-      uint32_t abr:2;
-      uint32_t tp:2;        //  7 t.p. mode (4,8,15bpp)
-      uint32_t dtd:1;       //  9 dither
-      uint32_t dfe:1;
-      uint32_t md:1;        // 11 set mask bit when drawing
-      uint32_t me:1;        // 12 no draw on mask
-      uint32_t unkn:3;
-      uint32_t width1:1;    // 16
-      uint32_t width0:2;
-      uint32_t dheight:1;   // 19 double height
-      uint32_t video:1;     // 20 NTSC,PAL
-      uint32_t rgb24:1;
-      uint32_t interlace:1; // 22 interlace on
-      uint32_t blanking:1;  // 23 display not enabled
-      uint32_t unkn2:2;
-      uint32_t busy:1;      // 26 !busy drawing
-      uint32_t img:1;       // 27 ready to DMA image data
-      uint32_t com:1;       // 28 ready for commands
-      uint32_t dma:2;       // 29 off, ?, to vram, from vram
-      uint32_t lcf:1;       // 31
-    };
-  } status;
+  uint32_t status;
   uint32_t gp0;
   uint32_t ex_regs[8];
   struct {

--- a/plugins/gpulib/gpu.h
+++ b/plugins/gpulib/gpu.h
@@ -19,6 +19,18 @@ extern "C" {
 
 #define CMD_BUFFER_LEN          1024
 
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define HTOLE32(x) __builtin_bswap32(x)
+#define HTOLE16(x) __builtin_bswap16(x)
+#define LE32TOH(x) __builtin_bswap32(x)
+#define LE16TOH(x) __builtin_bswap16(x)
+#else
+#define HTOLE32(x) (x)
+#define HTOLE16(x) (x)
+#define LE32TOH(x) (x)
+#define LE16TOH(x) (x)
+#endif
+
 #define BIT(x) (1 << (x))
 
 #define PSX_GPU_STATUS_DHEIGHT		BIT(19)

--- a/plugins/gpulib/vout_pl.c
+++ b/plugins/gpulib/vout_pl.c
@@ -36,7 +36,7 @@ static void check_mode_change(int force)
 
   gpu.state.enhancement_active =
     gpu.get_enhancement_bufer != NULL && gpu.state.enhancement_enable
-    && w <= 512 && h <= 256 && !gpu.status.rgb24;
+    && w <= 512 && h <= 256 && !(gpu.status & PSX_GPU_STATUS_RGB24);
 
   if (gpu.state.enhancement_active) {
     w_out *= 2;
@@ -53,12 +53,13 @@ static void check_mode_change(int force)
   }
 
   // width|rgb24 change?
-  if (force || (gpu.status.reg ^ old_status) & ((7<<16)|(1<<21)) || h != old_h)
+  if (force || (gpu.status ^ old_status) & ((7<<16)|(1<<21)) || h != old_h)
   {
-    old_status = gpu.status.reg;
+    old_status = gpu.status;
     old_h = h;
 
-    cbs->pl_vout_set_mode(w_out, h_out, w, h, gpu.status.rgb24 ? 24 : 16);
+    cbs->pl_vout_set_mode(w_out, h_out, w, h,
+          (gpu.status & PSX_GPU_STATUS_RGB24) ? 24 : 16);
   }
 }
 
@@ -94,7 +95,7 @@ void vout_update(void)
 
   vram += y * 1024 + x;
 
-  cbs->pl_vout_flip(vram, 1024, gpu.status.rgb24, w, h);
+  cbs->pl_vout_flip(vram, 1024, gpu.status & PSX_GPU_STATUS_RGB24, w, h);
 }
 
 void vout_blank(void)
@@ -107,7 +108,7 @@ void vout_blank(void)
     w *= 2;
     h *= 2;
   }
-  cbs->pl_vout_flip(NULL, 1024, gpu.status.rgb24, w, h);
+  cbs->pl_vout_flip(NULL, 1024, gpu.status & PSX_GPU_STATUS_RGB24, w, h);
 }
 
 long GPUopen(void **unused)


### PR DESCRIPTION
Equivalent to https://github.com/notaz/pcsx_rearmed/pull/142, but without the CI/buildscript changes that don't apply to libretro.

Hard work done by @pcercuei, I'm just PRing it.

Original description: 
> A couple of fixes to the PCSX core to make it able to run on big-endian systems.
Tested on 32-bit PPC.
> 
> The various GPU plugins would also need to be patched in order to access the VRAM properly.
