### PR TITLE
lightrec: Fix unmap size of BIOS

### DIFF
--- a/libpcsxcore/lightrec/mem.c
+++ b/libpcsxcore/lightrec/mem.c
@@ -190,7 +190,7 @@ int lightrec_init_mmap(void)
 err_unmap_scratch:
 	munmap(psxH, 0x10000);
 err_unmap_bios:
-	munmap(psxR, 0x80000);
+	munmap(psxR, 0x200000);
 err_unmap_parallel:
 	munmap(psxP, 0x10000);
 err_unmap:
@@ -205,7 +205,7 @@ void lightrec_free_mmap(void)
 
 	munmap(code_buffer, CODE_BUFFER_SIZE);
 	munmap(psxH, 0x10000);
-	munmap(psxR, 0x80000);
+	munmap(psxR, 0x200000);
 	munmap(psxP, 0x10000);
 	for (i = 0; i < 4; i++)
 		munmap((void *)((uintptr_t)psxM + i * 0x200000), 0x200000);

--- a/libpcsxcore/psxmem.c
+++ b/libpcsxcore/psxmem.c
@@ -175,7 +175,7 @@ int psxMemInit(void)
 	unsigned int i;
 	int ret;
 
-	if (LIGHTREC_CUSTOM_MAP && Config.Cpu == CPU_DYNAREC)
+	if (LIGHTREC_CUSTOM_MAP)
 		ret = lightrec_init_mmap();
 	else
 		ret = psxMemInitMap();
@@ -255,7 +255,7 @@ void psxMemReset() {
 }
 
 void psxMemShutdown() {
-	if (LIGHTREC_CUSTOM_MAP && Config.Cpu == CPU_DYNAREC)
+	if (LIGHTREC_CUSTOM_MAP)
 		lightrec_free_mmap();
 	else
 		psxMemFreeMap();


### PR DESCRIPTION
The BIOS was mapped as 2 MiB, since we want to use a huge page if
possible. Therefore it should also be unmapped as 2 MiB, otherwise the
upper 1.5 MiB will still be mapped after de-init, which will make it
impossible to map the BIOS once again.

Fixes #667.

Signed-off-by: Paul Cercueil <paul@crapouillou.net>