### PR TITLE
Update lightrec 20220716

### DIFF
--- a/deps/lightrec/.gitrepo
+++ b/deps/lightrec/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/pcercuei/lightrec.git
 	branch = master
-	commit = 30bad28d7a2b2903cd7f3d8024ae7a34a0c8b482
-	parent = 0141267e1c5e17c27548f6ad57c7acc22e589990
+	commit = 7545b5a7995be9e7b70e786a6b534004ea26c999
+	parent = 2fba93f2853c57240f031adb4712acbd2a066d34
 	method = merge
 	cmdver = 0.4.3

--- a/deps/lightrec/interpreter.c
+++ b/deps/lightrec/interpreter.c
@@ -63,7 +63,7 @@ static inline u32 jump_skip(struct interpreter *inter)
 	inter->op = next_op(inter);
 	inter->offset++;
 
-	if (inter->op->flags & LIGHTREC_SYNC) {
+	if (op_flag_sync(inter->op->flags)) {
 		inter->state->current_cycle += inter->cycles;
 		inter->cycles = 0;
 	}
@@ -101,8 +101,8 @@ static void update_cycles_before_branch(struct interpreter *inter)
 	if (!inter->delay_slot) {
 		cycles = lightrec_cycles_of_opcode(inter->op->c);
 
-		if (has_delay_slot(inter->op->c) &&
-		    !(inter->op->flags & LIGHTREC_NO_DS))
+		if (!op_flag_no_ds(inter->op->flags) &&
+		    has_delay_slot(inter->op->c))
 			cycles += lightrec_cycles_of_opcode(next_op(inter)->c);
 
 		inter->cycles += cycles;
@@ -329,7 +329,7 @@ static u32 int_jump(struct interpreter *inter, bool link)
 	if (link)
 		state->regs.gpr[31] = old_pc + 8;
 
-	if (inter->op->flags & LIGHTREC_NO_DS)
+	if (op_flag_no_ds(inter->op->flags))
 		return pc;
 
 	return int_delay_slot(inter, pc, true);
@@ -348,14 +348,18 @@ static u32 int_JAL(struct interpreter *inter)
 static u32 int_jumpr(struct interpreter *inter, u8 link_reg)
 {
 	struct lightrec_state *state = inter->state;
-	u32 old_pc, next_pc = state->regs.gpr[inter->op->r.rs];
+	u32 old_pc = int_get_branch_pc(inter);
+	u32 next_pc = state->regs.gpr[inter->op->r.rs];
 
-	if (link_reg) {
-		old_pc = int_get_branch_pc(inter);
-		state->regs.gpr[link_reg] = old_pc + 8;
+	if (op_flag_emulate_branch(inter->op->flags) && inter->offset) {
+		inter->cycles -= lightrec_cycles_of_opcode(inter->op->c);
+		return old_pc;
 	}
 
-	if (inter->op->flags & LIGHTREC_NO_DS)
+	if (link_reg)
+		state->regs.gpr[link_reg] = old_pc + 8;
+
+	if (op_flag_no_ds(inter->op->flags))
 		return next_pc;
 
 	return int_delay_slot(inter, next_pc, true);
@@ -373,8 +377,7 @@ static u32 int_special_JALR(struct interpreter *inter)
 
 static u32 int_do_branch(struct interpreter *inter, u32 old_pc, u32 next_pc)
 {
-	if (!inter->delay_slot &&
-	    (inter->op->flags & LIGHTREC_LOCAL_BRANCH) &&
+	if (!inter->delay_slot && op_flag_local_branch(inter->op->flags) &&
 	    (s16)inter->op->c.i.imm >= 0) {
 		next_pc = old_pc + ((1 + (s16)inter->op->c.i.imm) << 2);
 		next_pc = lightrec_emulate_block(inter->state, inter->block, next_pc);
@@ -388,9 +391,14 @@ static u32 int_branch(struct interpreter *inter, u32 pc,
 {
 	u32 next_pc = pc + 4 + ((s16)code.i.imm << 2);
 
+	if (op_flag_emulate_branch(inter->op->flags) && inter->offset) {
+		inter->cycles -= lightrec_cycles_of_opcode(inter->op->c);
+		return pc;
+	}
+
 	update_cycles_before_branch(inter);
 
-	if (inter->op->flags & LIGHTREC_NO_DS) {
+	if (op_flag_no_ds(inter->op->flags)) {
 		if (branch)
 			return int_do_branch(inter, pc, next_pc);
 		else
@@ -403,7 +411,7 @@ static u32 int_branch(struct interpreter *inter, u32 pc,
 	if (branch)
 		return int_do_branch(inter, pc, next_pc);
 
-	if (inter->op->flags & LIGHTREC_EMULATE_BRANCH)
+	if (op_flag_emulate_branch(inter->op->flags))
 		return pc + 8;
 	else
 		return jump_after_branch(inter);
@@ -497,7 +505,7 @@ static u32 int_ctc(struct interpreter *inter)
 	/* If we have a MTC0 or CTC0 to CP0 register 12 (Status) or 13 (Cause),
 	 * return early so that the emulator will be able to check software
 	 * interrupt status. */
-	if (!(inter->op->flags & LIGHTREC_NO_DS) &&
+	if (!op_flag_no_ds(inter->op->flags) &&
 	    op->i.op == OP_CP0 && (op->r.rd == 12 || op->r.rd == 13))
 		return int_get_ds_pc(inter, 1);
 	else
@@ -618,7 +626,7 @@ static u32 int_store(struct interpreter *inter)
 {
 	u32 next_pc;
 
-	if (likely(!(inter->op->flags & LIGHTREC_SMC)))
+	if (likely(!op_flag_smc(inter->op->flags)))
 		return int_io(inter, false);
 
 	lightrec_rw(inter->state, inter->op->c,
@@ -765,9 +773,9 @@ static u32 int_special_MULT(struct interpreter *inter)
 	u8 reg_hi = get_mult_div_hi(inter->op->c);
 	u64 res = (s64)rs * (s64)rt;
 
-	if (!(inter->op->flags & LIGHTREC_NO_HI))
+	if (!op_flag_no_hi(inter->op->flags))
 		reg_cache[reg_hi] = res >> 32;
-	if (!(inter->op->flags & LIGHTREC_NO_LO))
+	if (!op_flag_no_lo(inter->op->flags))
 		reg_cache[reg_lo] = res;
 
 	return jump_next(inter);
@@ -782,9 +790,9 @@ static u32 int_special_MULTU(struct interpreter *inter)
 	u8 reg_hi = get_mult_div_hi(inter->op->c);
 	u64 res = (u64)rs * (u64)rt;
 
-	if (!(inter->op->flags & LIGHTREC_NO_HI))
+	if (!op_flag_no_hi(inter->op->flags))
 		reg_cache[reg_hi] = res >> 32;
-	if (!(inter->op->flags & LIGHTREC_NO_LO))
+	if (!op_flag_no_lo(inter->op->flags))
 		reg_cache[reg_lo] = res;
 
 	return jump_next(inter);
@@ -807,9 +815,9 @@ static u32 int_special_DIV(struct interpreter *inter)
 		hi = rs % rt;
 	}
 
-	if (!(inter->op->flags & LIGHTREC_NO_HI))
+	if (!op_flag_no_hi(inter->op->flags))
 		reg_cache[reg_hi] = hi;
-	if (!(inter->op->flags & LIGHTREC_NO_LO))
+	if (!op_flag_no_lo(inter->op->flags))
 		reg_cache[reg_lo] = lo;
 
 	return jump_next(inter);
@@ -832,9 +840,9 @@ static u32 int_special_DIVU(struct interpreter *inter)
 		hi = rs % rt;
 	}
 
-	if (!(inter->op->flags & LIGHTREC_NO_HI))
+	if (!op_flag_no_hi(inter->op->flags))
 		reg_cache[reg_hi] = hi;
-	if (!(inter->op->flags & LIGHTREC_NO_LO))
+	if (!op_flag_no_lo(inter->op->flags))
 		reg_cache[reg_lo] = lo;
 
 	return jump_next(inter);

--- a/deps/lightrec/regcache.c
+++ b/deps/lightrec/regcache.c
@@ -493,6 +493,15 @@ void lightrec_clean_reg_if_loaded(struct regcache *cache, jit_state_t *_jit,
 	}
 }
 
+void lightrec_discard_reg_if_loaded(struct regcache *cache, u8 reg)
+{
+	struct native_register *nreg;
+
+	nreg = find_mapped_reg(cache, reg, false);
+	if (nreg)
+		lightrec_discard_nreg(nreg);
+}
+
 struct native_register * lightrec_regcache_enter_branch(struct regcache *cache)
 {
 	struct native_register *backup;

--- a/deps/lightrec/regcache.h
+++ b/deps/lightrec/regcache.h
@@ -50,6 +50,7 @@ void lightrec_storeback_regs(struct regcache *cache, jit_state_t *_jit);
 
 void lightrec_clean_reg_if_loaded(struct regcache *cache, jit_state_t *_jit,
 				  u8 reg, _Bool unload);
+void lightrec_discard_reg_if_loaded(struct regcache *cache, u8 reg);
 
 u8 lightrec_alloc_reg_in_address(struct regcache *cache,
 		jit_state_t *_jit, u8 reg, s16 offset);

--- a/libpcsxcore/lightrec/plugin.c
+++ b/libpcsxcore/lightrec/plugin.c
@@ -556,10 +556,13 @@ static void lightrec_plugin_reset(void)
 {
 	struct lightrec_registers *regs;
 
-	lightrec_plugin_shutdown();
-	lightrec_plugin_init();
-
 	regs = lightrec_get_registers(lightrec_state);
+
+	/* Invalidate all blocks */
+	lightrec_invalidate_all(lightrec_state);
+
+	/* Reset registers */
+	memset(regs, 0, sizeof(*regs));
 
 	regs->cp0[12] = 0x10900000; // COP0 enabled | BEV = 1 | TS = 1
 	regs->cp0[15] = 0x00000002; // PRevID = Revision ID, same as R3000A


### PR DESCRIPTION
When a dynarec plugin reset is requested, Lightrec will simply invalidate all emitted code and reset the registers to the default values, instead of destroying the existing instance to create a new one.

Bump Lightrec to the latest upstream version, which has seen quite a few changes, that should improve performance by a noticeable margin.