### PR TITLE
Update lightrec 20220912

### DIFF
--- a/deps/lightrec/.gitrepo
+++ b/deps/lightrec/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/pcercuei/lightrec.git
 	branch = master
-	commit = 071973e3ac26619cd3afbe339f020a2d4d61c28a
-	parent = cc8a5c0c654c18b3ad074e49f526cb6cae77f8b0
+	commit = 962ba057937b7fcb809f16682b4e24d27f08cdb1
+	parent = 5b2da975316f1d88d02a14f8f2c876b2213ff1f3
 	method = merge
 	cmdver = 0.4.3

--- a/deps/lightrec/optimizer.c
+++ b/deps/lightrec/optimizer.c
@@ -635,6 +635,10 @@ static u32 lightrec_propagate_consts(const struct opcode *op,
 			if (OPT_FLAG_MULT_DIV && c.r.imm)
 				known &= ~BIT(c.r.imm);
 			break;
+		case OP_SPECIAL_MFLO:
+		case OP_SPECIAL_MFHI:
+			known &= ~BIT(c.r.rd);
+			break;
 		default:
 			break;
 		}
@@ -1645,6 +1649,9 @@ static int lightrec_flag_io(struct lightrec_state *state, struct block *block)
 						pr_debug("Flagging opcode %u as direct I/O access\n",
 							 i);
 						list->flags |= LIGHTREC_IO_MODE(LIGHTREC_IO_DIRECT_HW);
+
+						if (no_mask)
+							list->flags |= LIGHTREC_NO_MASK;
 						break;
 					}
 					fallthrough;

--- a/libpcsxcore/lightrec/plugin.c
+++ b/libpcsxcore/lightrec/plugin.c
@@ -54,7 +54,6 @@ static char *name = "retroarch.exe";
 static bool use_lightrec_interpreter;
 static bool use_pcsx_interpreter;
 static bool booting;
-static u32 lightrec_begin_cycles;
 
 enum my_cp2_opcodes {
 	OP_CP2_RTPS		= 0x01,
@@ -403,9 +402,6 @@ static int lightrec_plugin_init(void)
 	}
 
 	use_lightrec_interpreter = !!getenv("LIGHTREC_INTERPRETER");
-	if (getenv("LIGHTREC_BEGIN_CYCLES"))
-	  lightrec_begin_cycles = (unsigned int) strtol(
-				  getenv("LIGHTREC_BEGIN_CYCLES"), NULL, 0);
 
 	lightrec_state = lightrec_init(name,
 			lightrec_map, ARRAY_SIZE(lightrec_map),

--- a/libpcsxcore/lightrec/plugin.c
+++ b/libpcsxcore/lightrec/plugin.c
@@ -344,7 +344,7 @@ static bool lightrec_can_hw_direct(u32 kaddr, bool is_write, u8 size)
 		case 0x1f801074:
 			return !is_write;
 		default:
-			return is_write || kaddr < 0x1f801c00 || kaddr >= 0x1f801e00;
+			return kaddr < 0x1f801c00 || kaddr >= 0x1f801e00;
 		}
 	default:
 		switch (kaddr) {


### PR DESCRIPTION
Small fixes:
- Fix crash in Sled Storm during / after the intro FMV
- Fix the lights on the monkeys in Ape's Escape