### PR TITLE
Expand usable space for GunCon

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -2421,17 +2421,19 @@ static void update_input_guncon(int port, int ret)
    //Mouse range is -32767 -> 32767
    //1% is about 655
    //Use the left analog stick field to store the absolute coordinates
-   //Fix cursor to top-left when gun is detected as "offscreen"
+
+   int gunx = input_state_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X);
+   int guny = input_state_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y);
+
+   //Have the Libretro API let /libpcsxcore/plugins.c know when the lightgun is pointed offscreen
+   //Offscreen value is chosen to be well out of range of any possible scaling done via core options
    if (input_state_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_IS_OFFSCREEN) || input_state_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_RELOAD))
    {
-      in_analog_left[port][0] = -32767;
-      in_analog_left[port][1] = -32767;
+      in_analog_left[port][0] = (65536 - 512) * 64;
+      in_analog_left[port][1] = (65536 - 512) * 64;
    }
    else
    {
-      int gunx = input_state_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_X);
-      int guny = input_state_cb(port, RETRO_DEVICE_LIGHTGUN, 0, RETRO_DEVICE_ID_LIGHTGUN_SCREEN_Y);
-	   
       in_analog_left[port][0] = (gunx * GunconAdjustRatioX) + (GunconAdjustX * 655);
       in_analog_left[port][1] = (guny * GunconAdjustRatioY) + (GunconAdjustY * 655);
    }

--- a/libpcsxcore/plugins.c
+++ b/libpcsxcore/plugins.c
@@ -664,28 +664,17 @@ void _PADstartPoll(PadDataS *pad) {
 			int absX = (pad->absoluteX / 64) + 512;
 			int absY = (pad->absoluteY / 64) + 512;
 
-			//Keep within limits
-			if (absX > 1023) absX = 1023;
-			if (absX < 0) absX = 0;
-			if (absY > 1023) absY = 1023;
-			if (absY < 0) absY = 0;
-
-			stdpar[4] = 0x5a - (xres - 256) / 3 + (((xres - 256) / 3 + 356) * absX >> 10);
-			stdpar[5] = (0x5a - (xres - 256) / 3 + (((xres - 256) / 3 + 356) * absX >> 10)) >> 8;
-			stdpar[6] = 0x20 + (yres * absY >> 10);
-			stdpar[7] = (0x20 + (yres * absY >> 10)) >> 8;
-
-			//Offscreen - Point at the side of the screen so PSX thinks you are pointing offscreen
-			//Required as a mouse can't be offscreen
-			//Coordinates X=0001h, Y=000Ah indicates "no light"
-			//This will mean you cannot shoot the very each of the screen
-			//ToDo read offscreen range from settings if useful to change
-			int OffscreenRange = 2;
-			if (absX < (OffscreenRange) || absX > (1023 - OffscreenRange) || absY < (OffscreenRange) || absY > (1023 - OffscreenRange)) {
-				stdpar[4] = 0x01;
-				stdpar[5] = 0x00;
-				stdpar[6] = 0x0A;
-				stdpar[7] = 0x00;
+			if (absX == 65536 || absY == 65536) {
+			   stdpar[4] = 0x01;
+			   stdpar[5] = 0x00;
+			   stdpar[6] = 0x0A;
+			   stdpar[7] = 0x00;
+			}
+			else {
+			   stdpar[4] = 0x5a - (xres - 256) / 3 + (((xres - 256) / 3 + 356) * absX >> 10);
+			   stdpar[5] = (0x5a - (xres - 256) / 3 + (((xres - 256) / 3 + 356) * absX >> 10)) >> 8;
+			   stdpar[6] = 0x20 + (yres * absY >> 10);
+			   stdpar[7] = (0x20 + (yres * absY >> 10)) >> 8;
 			}
 
 			memcpy(buf, stdpar, 8);


### PR DESCRIPTION
Some background discussion on the issue I try to solve with this is in #655.

The short explanation is that manually scaling/shifting the GunCon coordinates via the core options will often shrink the amount of space usable by a lightgun device due to the way the emulator sets strict bounds for the gun coordinates. These suggested changes open up the range of values and redefine what "offscreen" means in terms of the Libretro API instead of the original fixed range of values.

I initially tried to do this:

I wanted to adapt the coordinate formulas from page 162 of [this document](https://static.grumpycoder.net/pixel/document.pdf) to hopefully eliminate the need for manual scaling via the core options, but I kept running into inconsistencies. There appear to be three possible ways that games scaled the horizontal coordinates, but I couldn't find a pattern based on region/resolution alone. In addition, some games scale the coordinates to a space smaller than the total area of the screen (see Extreme Ghostbusters: The Ultimate Invasion's dead space on the top and left of the screen), while using the enhanced resolution of the emulator further throws a wrench in things. You will see in the linked issue that the discussion led to us spinning our wheels wondering why all games couldn't have a unified formula that scaled the coordinates based on region and resolution.

The suggested changes here maintain the coordinate formulas because all games appear to work and can at least be manually scaled to a lightgun user's device via the core options. Please feel free to make suggestions for improvements or to use this as inspiration for a better solution.