### PR TITLE
libretro: Fix huge performance drop

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -27,6 +27,7 @@
 #include "../libpcsxcore/cdriso.h"
 #include "../libpcsxcore/cheat.h"
 #include "../libpcsxcore/r3000a.h"
+#include "../libpcsxcore/lightrec/plugin.h"
 #include "../plugins/dfsound/out.h"
 #include "../plugins/dfsound/spu_config.h"
 #include "../plugins/dfinput/externals.h"
@@ -1953,6 +1954,9 @@ static void update_variables(bool in_flight)
       bool can_use_dynarec = 1;
 #endif
 
+      if (drc_is_lightrec() && Config.Cpu != CPU_INTERPRETER)
+          lightrec_plugin_sync_regs_to_pcsx();
+
 #ifdef _3DS
       if (!__ctr_svchax)
          Config.Cpu = CPU_INTERPRETER;
@@ -1971,6 +1975,9 @@ static void update_variables(bool in_flight)
          psxCpu->Reset(); // not really a reset..
       }
    }
+
+   if (drc_is_lightrec() && Config.Cpu != CPU_INTERPRETER)
+       lightrec_plugin_sync_regs_from_pcsx();
 #endif /* !DRC_DISABLE */
 
    var.value = NULL;

--- a/libpcsxcore/lightrec/plugin.c
+++ b/libpcsxcore/lightrec/plugin.c
@@ -496,13 +496,8 @@ static void lightrec_plugin_execute(void)
 {
 	extern int stop;
 
-	if (!booting)
-		lightrec_plugin_sync_regs_from_pcsx();
-
 	while (!stop)
 		lightrec_plugin_execute_internal(false);
-
-	lightrec_plugin_sync_regs_to_pcsx();
 }
 
 static void lightrec_plugin_execute_block(void)


### PR DESCRIPTION
Libretro runs the Cpu->Execute() callback just for a frame and then stops it. Because of recent changes (d0abba5 and 2c78ad6), Lightrec's code buffer was being flushed at every single frame, killing the performance in the process.

Address this issue while retaining the ability to switch between the interpreter and dynarec by moving some code around.