### PR TITLE
Don't strip debug build

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -505,7 +505,10 @@ else ifeq ($(platform), emscripten)
 else
 	TARGET := $(TARGET_NAME)_libretro.dll
 	PLATFORM = libretro
-	MAIN_LDFLAGS += -static-libgcc -static-libstdc++ -s
+	MAIN_LDFLAGS += -static-libgcc -static-libstdc++
+ifneq ($(DEBUG),1)
+	MAIN_LDFLAGS += -s
+endif
 	CFLAGS += -D__WIN32__ -DNO_DYLIB
 	MMAP_WIN32=1
 	MAIN_LDLIBS += -lws2_32


### PR DESCRIPTION
Idk much about Makefile so maybe there's a better way to handle this? Seems to work fine for me with MinGW at least...

In any case, this is very annoying to have to manually remove that "-s" every time you want to build with DEBUG=1 on Windows :p 