### PR TITLE
Fix Win32 build, part 2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,7 @@ OBJS += deps/lightning/lib/jit_disasm.o \
 		deps/lightrec/memmanager.o \
 		deps/lightrec/optimizer.o \
 		deps/lightrec/regcache.o
+deps/lightning/%.o: CFLAGS += -DHAVE_MMAP=P_HAVE_MMAP
 libpcsxcore/lightrec/mem.o: CFLAGS += -D_GNU_SOURCE
 ifeq ($(MMAP_WIN32),1)
 CFLAGS += -Iinclude/mman -I deps/mman


### PR DESCRIPTION
Untested, but this should work.

GNU Lightning does use the 'HAVE_MMAP' macro, so it needs to be defined when compiling it; otherwise Lightning will fail on an assert() at runtime.