### PR TITLE
make: Enable Lightrec for GC/Wii

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,9 @@ ifeq ($(LIGHTREC_CUSTOM_MAP),1)
 LDLIBS += -lrt
 OBJS += $(LIGHTREC_CUSTOM_MAP_OBJ)
 endif
+ifeq ($(NEED_SYSCONF),1)
+OBJS += libpcsxcore/lightrec/sysconf.o
+endif
 ifeq ($(LIGHTREC_THREADED_COMPILER),1)
 OBJS += deps/lightrec/recompiler.o \
 	deps/lightrec/reaper.o

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -330,10 +330,10 @@ else ifneq (,$(filter $(platform),ngc wii wiiu))
 	TARGET := $(TARGET_NAME)_libretro_$(platform).a
 	ifeq ($(platform), ngc)
 		CFLAGS += -DHW_DOL -mogc
-		DYNAREC := 0 # missing sysconf()
+		NEED_SYSCONF := 1
 	else ifeq ($(platform), wii)
 		CFLAGS += -DHW_RVL -mrvl
-		DYNAREC := 0 # missing sysconf()
+		NEED_SYSCONF := 1
 	else ifeq ($(platform), wiiu)
 		# -mwup was removed in newer devkitPPC versions
 		CFLAGS += -DHW_WUP

--- a/libpcsxcore/lightrec/sysconf.c
+++ b/libpcsxcore/lightrec/sysconf.c
@@ -1,0 +1,13 @@
+#include <errno.h>
+#include <unistd.h>
+
+/* Implement the sysconf() symbol which is needed by GNU Lightning */
+long sysconf(int name)
+{
+	switch (name) {
+	case _SC_PAGE_SIZE:
+		return 4096;
+	default:
+		return -EINVAL;
+	}
+}


### PR DESCRIPTION
Add the missing sysconf() function so that the GC/Wii builds will link properly against Lightrec and GNU Lightning.

Note that the actual page size returned doesn't really matter - it is used by Lightning to align the size of code blocks to be flushed with GCC's __clear_cache, which is a NOP on the GC/Wii.