### PR TITLE
lightrec: Alloc code buffer with standard memory map

### DIFF
--- a/libpcsxcore/lightrec/mem.c
+++ b/libpcsxcore/lightrec/mem.c
@@ -31,8 +31,6 @@
 #define MFD_HUGETLB 0x0004
 #endif
 
-void *code_buffer;
-
 static const uintptr_t supported_io_bases[] = {
 	0x0,
 	0x10000000,

--- a/libpcsxcore/lightrec/mem_wiiu.c
+++ b/libpcsxcore/lightrec/mem_wiiu.c
@@ -14,8 +14,6 @@
 
 #include "mem.h"
 
-void* code_buffer;
-
 static void* wiiu_mmap(uint32_t requested_va, size_t length, void* backing_mem) {
 	if (length < OS_PAGE_SIZE) length = OS_PAGE_SIZE;
 


### PR DESCRIPTION
Provide Lightrec with a code buffer even when using a non-custom memory map, as some platforms (NGC, Wii) cannot emit code outside a provided code buffer.