### PR TITLE
lightrec: Allow to override code buffer size

### DIFF
--- a/libpcsxcore/lightrec/mem.h
+++ b/libpcsxcore/lightrec/mem.h
@@ -9,11 +9,15 @@
 #ifdef LIGHTREC
 
 #ifdef HW_WUP /* WiiU */
-#    define WUP_RWX_MEM_BASE	0x00802000
-#    define WUP_RWX_MEM_END	0x01000000
-#    define CODE_BUFFER_SIZE	(WUP_RWX_MEM_END - WUP_RWX_MEM_BASE)
+#    define WUP_RWX_MEM_BASE		0x00802000
+#    define WUP_RWX_MEM_END		0x01000000
+#    define CODE_BUFFER_SIZE_DFT	(WUP_RWX_MEM_END - WUP_RWX_MEM_BASE)
 #else
-#    define CODE_BUFFER_SIZE	(8 * 1024 * 1024)
+#    define CODE_BUFFER_SIZE_DFT	(8 * 1024 * 1024)
+#endif
+
+#ifndef CODE_BUFFER_SIZE
+#define CODE_BUFFER_SIZE CODE_BUFFER_SIZE_DFT
 #endif
 
 extern void *code_buffer;


### PR DESCRIPTION
Allow the CODE_BUFFER_SIZE macro to be overriden.

This is helpful on platforms that don't want a 8 MiB buffer.