### PR TITLE
libpcsxcore: Add database for Lightrec hacks

### DIFF
--- a/libpcsxcore/database.c
+++ b/libpcsxcore/database.c
@@ -1,9 +1,15 @@
 #include "misc.h"
 #include "sio.h"
 #include "new_dynarec/new_dynarec.h"
+#include "lightrec/plugin.h"
 
 /* It's duplicated from emu_if.c */
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+
+/* Corresponds to LIGHTREC_OPT_INV_DMA_ONLY of lightrec.h */
+#define LIGHTREC_HACK_INV_DMA_ONLY (1 << 0)
+
+u32 lightrec_hacks;
 
 static const char * const MemorycardHack_db[] =
 {
@@ -75,6 +81,35 @@ cycle_multiplier_overrides[] =
 	{ "SLES02064", 222 },
 };
 
+static const struct
+{
+	const char * const id;
+	u32 hacks;
+}
+lightrec_hacks_db[] =
+{
+	/* Formula One Arcade */
+	{ "SCES03886", LIGHTREC_HACK_INV_DMA_ONLY },
+
+	/* Formula One '99 */
+	{ "SLUS00870", LIGHTREC_HACK_INV_DMA_ONLY },
+	{ "SCPS10101", LIGHTREC_HACK_INV_DMA_ONLY },
+	{ "SCES01979", LIGHTREC_HACK_INV_DMA_ONLY },
+	{ "SLES01979", LIGHTREC_HACK_INV_DMA_ONLY },
+
+	/* Formula One 2000 */
+	{ "SLUS01134", LIGHTREC_HACK_INV_DMA_ONLY },
+	{ "SCES02777", LIGHTREC_HACK_INV_DMA_ONLY },
+	{ "SCES02778", LIGHTREC_HACK_INV_DMA_ONLY },
+	{ "SCES02779", LIGHTREC_HACK_INV_DMA_ONLY },
+
+	/* Formula One 2001 */
+	{ "SCES03404", LIGHTREC_HACK_INV_DMA_ONLY },
+	{ "SCES03423", LIGHTREC_HACK_INV_DMA_ONLY },
+	{ "SCES03424", LIGHTREC_HACK_INV_DMA_ONLY },
+	{ "SCES03524", LIGHTREC_HACK_INV_DMA_ONLY },
+};
+
 /* Function for automatic patching according to GameID. */
 void Apply_Hacks_Cdrom()
 {
@@ -119,6 +154,17 @@ void Apply_Hacks_Cdrom()
 			new_dynarec_hacks_pergame |= NDHACK_OVERRIDE_CYCLE_M;
 			SysPrintf("using cycle_multiplier_override: %d\n",
 				Config.cycle_multiplier_override);
+			break;
+		}
+	}
+
+	lightrec_hacks = 0;
+
+	for (i = 0; drc_is_lightrec() && i < ARRAY_SIZE(lightrec_hacks_db); i++) {
+		if (strcmp(CdromId, lightrec_hacks_db[i].id) == 0)
+		{
+			lightrec_hacks = lightrec_hacks_db[i].hacks;
+			SysPrintf("using lightrec_hacks: 0x%x\n", lightrec_hacks);
 			break;
 		}
 	}

--- a/libpcsxcore/lightrec/plugin.c
+++ b/libpcsxcore/lightrec/plugin.c
@@ -66,6 +66,8 @@ static bool use_lightrec_interpreter;
 static bool use_pcsx_interpreter;
 static bool block_stepping;
 
+extern u32 lightrec_hacks;
+
 enum my_cp2_opcodes {
 	OP_CP2_RTPS		= 0x01,
 	OP_CP2_NCLIP		= 0x06,
@@ -467,6 +469,8 @@ static int lightrec_plugin_init(void)
 	lightrec_state = lightrec_init(name,
 			lightrec_map, ARRAY_SIZE(lightrec_map),
 			&lightrec_ops);
+
+	lightrec_set_unsafe_opt_flags(lightrec_state, lightrec_hacks);
 
 	// fprintf(stderr, "M=0x%lx, P=0x%lx, R=0x%lx, H=0x%lx\n",
 	// 		(uintptr_t) psxM,


### PR DESCRIPTION
And add entries for the infamous Formula One games.

These games do tricks with the instruction cache that are hard to emulate properly in an interpreter, and almost impossible in a dynamic recompiler.

Funnily enough, emulating the CPU less accurately by only invalidating cached code on DMA writes and never on CPU writes make these games work.

These hacks will also make Lightrec generate faster code, but they are unsafe by nature, and that's why they are conditionally enabled.