### PR TITLE
unai: Fix scalers doing endianness conversion

### DIFF
--- a/plugins/gpu_unai/gpu_unai.h
+++ b/plugins/gpu_unai/gpu_unai.h
@@ -181,7 +181,7 @@ struct gpu_unai_t {
 	le16_t *vram;
 
 #ifdef USE_GPULIB
-	u16 *downscale_vram;
+	le16_t *downscale_vram;
 #endif
 	////////////////////////////////////////////////////////////////////////////
 	// Variables used only by older standalone version of gpu_unai (gpu.cpp)


### PR DESCRIPTION
Both the VRAM and the downscale buffers are in little-endian format, there's no need to do any endianness conversion.