### PR TITLE
Timing hack for Metal Gear Solid

### DIFF
--- a/libpcsxcore/database.c
+++ b/libpcsxcore/database.c
@@ -98,6 +98,10 @@ cycle_multiplier_overrides[] =
 	{ "SLES02914", 153 },
 	/* Syphon Filter - reportedly hangs under unknown conditions */
 	{ "SCUS94240", 169 },
+	/* Metal Gear Solid - stutters during cutscenes */
+	{ "SLUS00594", 117 },
+	{ "SLUS00776", 117 },
+	{ "SLUS00957", 117 },
 };
 
 static const struct


### PR DESCRIPTION
Metal Gear Solid stutters during the cutscenes (notably in the heliport). A cpu clock value of "85" seems to fix the NTSC-U version, while the PAL still stutters.