### PR TITLE
Add missing #if for the "Threaded SPU" core option

### DIFF
--- a/frontend/libretro.c
+++ b/frontend/libretro.c
@@ -2240,6 +2240,7 @@ static void update_variables(bool in_flight)
          spu_config.iUseInterpolation = 0;
    }
 
+#if P_HAVE_PTHREAD
    var.value = NULL;
    var.key = "pcsx_rearmed_spu_thread";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
@@ -2249,6 +2250,7 @@ static void update_variables(bool in_flight)
       else
          spu_config.iUseThread = 0;
    }
+#endif
 
 #if 0 // currently disabled, see USE_READ_THREAD in libpcsxcore/cdriso.c
    if (P_HAVE_PTHREAD) {


### PR DESCRIPTION
To match the #if from libretro_core_options.h: https://github.com/libretro/pcsx_rearmed/blob/81574accf59f445626568ec6b4388d887ddc8595/frontend/libretro_core_options.h#L798-L813

so it silences this error every time the core checks core options:
> [ERROR] [Environ]: GET_VARIABLE: pcsx_rearmed_spu_thread - Invalid value.