### PR TITLE
Address sanitizer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,9 @@ else
 CFLAGS += -O2 -DNDEBUG
 endif
 endif
+ifeq ($(DEBUG_ASAN), 1)
+CFLAGS += -fsanitize=address
+endif
 CFLAGS += -DP_HAVE_MMAP=$(if $(NO_MMAP),0,1) \
 	  -DP_HAVE_PTHREAD=$(if $(NO_PTHREAD),0,1) \
 	  -DP_HAVE_POSIX_MEMALIGN=$(if $(NO_POSIX_MEMALIGN),0,1) \
@@ -45,6 +48,9 @@ endif
 CC_LINK ?= $(CC)
 CC_AS ?= $(CC)
 LDFLAGS += $(MAIN_LDFLAGS)
+ifeq ($(DEBUG_ASAN), 1)
+LDFLAGS += -static-libasan
+endif
 EXTRA_LDFLAGS ?= -Wl,-Map=$@.map
 LDLIBS += $(MAIN_LDLIBS)
 ifdef PCNT

--- a/frontend/menu.c
+++ b/frontend/menu.c
@@ -217,7 +217,7 @@ static int optional_cdimg_filter(struct dirent **namelist, int count,
 	const char *basedir)
 {
 	const char *ext, *p;
-	char buf[256], buf2[256];
+	char buf[256], buf2[257];
 	int i, d, ret, good_cue;
 	struct STAT statf;
 	FILE *f;


### PR DESCRIPTION
Enable GCC's (or LLVM's) Address Sanitizer when DEBUG=1 is set.

As it says in the commit message, this is not available everywhere, so if you think it's a problem I can enable it through a "DEBUG_ASAN" variable or something like that.

It detects a lot of problems, one of which I fixed in Lightrec in PR #801, another one in the frontend that I fixed here.

It detects other issues, notably in the SPU plugin (reproducible in Duke Nukem Total Meltdon, boot the game and leave it running until the emulator exits) that have yet to be fixed.