### PR TITLE
Update Lightrec 2023-11-24

### DIFF
--- a/deps/lightrec/.gitrepo
+++ b/deps/lightrec/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/pcercuei/lightrec.git
 	branch = master
-	commit = 109d0a6ba35d0279b9d0bf5bacafabc2d634af7b
-	parent = 99104c0456c7c923f40a474c1cbefb89a092b966
+	commit = b8ce1f3dab45d7c665aa406a0ff183ae6565205d
+	parent = 305945333b4ec7d6910a077278c850b1cd887057
 	method = merge
 	cmdver = 0.4.6


### PR DESCRIPTION
Should fix #782 and maybe other games. Lightrec was sometimes returning from exceptions one opcode before the actual target, which potentially caused all kind of nasty effects in affected games; e.g. missing polygons in Colin Mc Rae Rally and Vagrant Story, and crashes in Um Jammer Lammy.