### PR TITLE
lightrec: Improve hack around icache emulation

### DIFF
--- a/libpcsxcore/lightrec/plugin.c
+++ b/libpcsxcore/lightrec/plugin.c
@@ -571,7 +571,8 @@ static void lightrec_plugin_execute_block(enum blockExecCaller caller)
 
 static void lightrec_plugin_clear(u32 addr, u32 size)
 {
-	if (addr == 0 && size == UINT32_MAX)
+	if ((addr == 0 && size == UINT32_MAX)
+	    || (lightrec_hacks & LIGHTREC_OPT_INV_DMA_ONLY))
 		lightrec_invalidate_all(lightrec_state);
 	else
 		/* size * 4: PCSX uses DMA units */


### PR DESCRIPTION
Invalidate the whole code buffer on each call to the .clear callback. This fixes a crash after finishing a race in F1 Arcade, and does not seem to cause issues with the other F1 games.

Fixes #788.