### PR TITLE
Fix emscripten build target

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -544,7 +544,11 @@ else ifeq ($(platform), miyoo)
 else ifeq ($(platform), emscripten)
    TARGET  := $(TARGET_NAME)_libretro_$(platform).bc
    fpic    := -fPIC
-   CFLAGS += -DNO_DYLIB
+   NO_MMAP = 1
+   CFLAGS += -DNO_DYLIB -DNO_SOCKET
+   CFLAGS += -msimd128 -ftree-vectorize
+   LIBPTHREAD :=
+   NO_PTHREAD=1
    DYNAREC =
    STATIC_LINKING = 1
 

--- a/frontend/main.c
+++ b/frontend/main.c
@@ -31,7 +31,9 @@
 #include "arm_features.h"
 #include "revision.h"
 
-#if defined(__has_builtin)
+#if defined(__EMSCRIPTEN__)
+#define DO_CPU_CHECKS 0
+#elif defined(__has_builtin)
 #define DO_CPU_CHECKS __has_builtin(__builtin_cpu_init)
 #elif defined(__x86_64__) || defined(__i386__)
 #define DO_CPU_CHECKS 1


### PR DESCRIPTION
Emscripten 3.1.53 causes attempted cpu checks to now fail with "unsupported platform"

Enables `NO_MMAP` and `NO_PTHREAD`