### PR TITLE
lightning.h: Bump to latest version

### DIFF
--- a/include/lightning/lightning.h
+++ b/include/lightning/lightning.h
@@ -23,6 +23,7 @@
 #include <unistd.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 #include <pthread.h>
 
@@ -1210,6 +1211,119 @@ typedef enum {
 #define jit_hmuli_u(u,v,w)	jit_new_node_www(jit_code_hmuli_u,u,v,w)
     jit_code_hmulr_u,		jit_code_hmuli_u,
 
+#define jit_ldxbr_c(u,v,w)	jit_new_node_www(jit_code_ldxbr_c,u,v,w)
+#define jit_ldxbi_c(u,v,w)	jit_new_node_www(jit_code_ldxbi_c,u,v,w)
+    jit_code_ldxbr_c,		jit_code_ldxbi_c,
+#define jit_ldxar_c(u,v,w)	jit_new_node_www(jit_code_ldxar_c,u,v,w)
+#define jit_ldxai_c(u,v,w)	jit_new_node_www(jit_code_ldxai_c,u,v,w)
+    jit_code_ldxar_c,		jit_code_ldxai_c,
+#define jit_ldxbr_uc(u,v,w)	jit_new_node_www(jit_code_ldxbr_uc,u,v,w)
+#define jit_ldxbi_uc(u,v,w)	jit_new_node_www(jit_code_ldxbi_uc,u,v,w)
+    jit_code_ldxbr_uc,		jit_code_ldxbi_uc,
+#define jit_ldxar_uc(u,v,w)	jit_new_node_www(jit_code_ldxar_uc,u,v,w)
+#define jit_ldxai_uc(u,v,w)	jit_new_node_www(jit_code_ldxai_uc,u,v,w)
+    jit_code_ldxar_uc,		jit_code_ldxai_uc,
+#define jit_ldxbr_s(u,v,w)	jit_new_node_www(jit_code_ldxbr_s,u,v,w)
+#define jit_ldxbi_s(u,v,w)	jit_new_node_www(jit_code_ldxbi_s,u,v,w)
+    jit_code_ldxbr_s,		jit_code_ldxbi_s,
+#define jit_ldxar_s(u,v,w)	jit_new_node_www(jit_code_ldxar_s,u,v,w)
+#define jit_ldxai_s(u,v,w)	jit_new_node_www(jit_code_ldxai_s,u,v,w)
+    jit_code_ldxar_s,		jit_code_ldxai_s,
+#define jit_ldxbr_us(u,v,w)	jit_new_node_www(jit_code_ldxbr_us,u,v,w)
+#define jit_ldxbi_us(u,v,w)	jit_new_node_www(jit_code_ldxbi_us,u,v,w)
+    jit_code_ldxbr_us,		jit_code_ldxbi_us,
+#define jit_ldxar_us(u,v,w)	jit_new_node_www(jit_code_ldxar_us,u,v,w)
+#define jit_ldxai_us(u,v,w)	jit_new_node_www(jit_code_ldxai_us,u,v,w)
+    jit_code_ldxar_us,		jit_code_ldxai_us,
+#define jit_ldxbr_i(u,v,w)	jit_new_node_www(jit_code_ldxbr_i,u,v,w)
+#define jit_ldxbi_i(u,v,w)	jit_new_node_www(jit_code_ldxbi_i,u,v,w)
+    jit_code_ldxbr_i,		jit_code_ldxbi_i,
+#define jit_ldxar_i(u,v,w)	jit_new_node_www(jit_code_ldxar_i,u,v,w)
+#define jit_ldxai_i(u,v,w)	jit_new_node_www(jit_code_ldxai_i,u,v,w)
+    jit_code_ldxar_i,		jit_code_ldxai_i,
+#if __WORDSIZE == 32
+#  define jit_ldxbr(u,v,w)	jit_ldxbr_i(u,v,w)
+#  define jit_ldxbi(u,v,w)	jit_ldxbi_i(u,v,w)
+#  define jit_ldxar(u,v,w)	jit_ldxar_i(u,v,w)
+#  define jit_ldxai(u,v,w)	jit_ldxai_i(u,v,w)
+#else
+#  define jit_ldxbr(u,v,w)	jit_ldxbr_l(u,v,w)
+#  define jit_ldxbi(u,v,w)	jit_ldxbi_l(u,v,w)
+#  define jit_ldxar(u,v,w)	jit_ldxar_l(u,v,w)
+#  define jit_ldxai(u,v,w)	jit_ldxai_l(u,v,w)
+#  define jit_ldxbr_ui(u,v,w)	jit_new_node_www(jit_code_ldxbr_ui,u,v,w)
+#  define jit_ldxbi_ui(u,v,w)	jit_new_node_www(jit_code_ldxbi_ui,u,v,w)
+#  define jit_ldxar_ui(u,v,w)	jit_new_node_www(jit_code_ldxar_ui,u,v,w)
+#  define jit_ldxai_ui(u,v,w)	jit_new_node_www(jit_code_ldxai_ui,u,v,w)
+#  define jit_ldxbr_l(u,v,w)	jit_new_node_www(jit_code_ldxbr_l,u,v,w)
+#  define jit_ldxbi_l(u,v,w)	jit_new_node_www(jit_code_ldxbi_l,u,v,w)
+#  define jit_ldxar_l(u,v,w)	jit_new_node_www(jit_code_ldxar_l,u,v,w)
+#  define jit_ldxai_l(u,v,w)	jit_new_node_www(jit_code_ldxai_l,u,v,w)
+#endif
+    jit_code_ldxbr_ui,		jit_code_ldxbi_ui,
+    jit_code_ldxar_ui,		jit_code_ldxai_ui,
+    jit_code_ldxbr_l,		jit_code_ldxbi_l,
+    jit_code_ldxar_l,		jit_code_ldxai_l,
+#  define jit_ldxbr_f(u,v,w)	jit_new_node_www(jit_code_ldxbr_f,u,v,w)
+#  define jit_ldxbi_f(u,v,w)	jit_new_node_www(jit_code_ldxbi_f,u,v,w)
+#  define jit_ldxar_f(u,v,w)	jit_new_node_www(jit_code_ldxar_f,u,v,w)
+#  define jit_ldxai_f(u,v,w)	jit_new_node_www(jit_code_ldxai_f,u,v,w)
+    jit_code_ldxbr_f,		jit_code_ldxbi_f,
+    jit_code_ldxar_f,		jit_code_ldxai_f,
+#  define jit_ldxbr_d(u,v,w)	jit_new_node_www(jit_code_ldxbr_d,u,v,w)
+#  define jit_ldxbi_d(u,v,w)	jit_new_node_www(jit_code_ldxbi_d,u,v,w)
+#  define jit_ldxar_d(u,v,w)	jit_new_node_www(jit_code_ldxar_d,u,v,w)
+#  define jit_ldxai_d(u,v,w)	jit_new_node_www(jit_code_ldxai_d,u,v,w)
+    jit_code_ldxbr_d,		jit_code_ldxbi_d,
+    jit_code_ldxar_d,		jit_code_ldxai_d,
+#define jit_stxbr_c(u,v,w)	jit_new_node_www(jit_code_stxbr_c,u,v,w)
+#define jit_stxbi_c(u,v,w)	jit_new_node_www(jit_code_stxbi_c,u,v,w)
+#define jit_stxar_c(u,v,w)	jit_new_node_www(jit_code_stxar_c,u,v,w)
+#define jit_stxai_c(u,v,w)	jit_new_node_www(jit_code_stxai_c,u,v,w)
+    jit_code_stxbr_c,		jit_code_stxbi_c,
+    jit_code_stxar_c,		jit_code_stxai_c,
+#define jit_stxbr_s(u,v,w)	jit_new_node_www(jit_code_stxbr_s,u,v,w)
+#define jit_stxbi_s(u,v,w)	jit_new_node_www(jit_code_stxbi_s,u,v,w)
+#define jit_stxar_s(u,v,w)	jit_new_node_www(jit_code_stxar_s,u,v,w)
+#define jit_stxai_s(u,v,w)	jit_new_node_www(jit_code_stxai_s,u,v,w)
+    jit_code_stxbr_s,		jit_code_stxbi_s,
+    jit_code_stxar_s,		jit_code_stxai_s,
+#define jit_stxbr_i(u,v,w)	jit_new_node_www(jit_code_stxbr_i,u,v,w)
+#define jit_stxbi_i(u,v,w)	jit_new_node_www(jit_code_stxbi_i,u,v,w)
+#define jit_stxar_i(u,v,w)	jit_new_node_www(jit_code_stxar_i,u,v,w)
+#define jit_stxai_i(u,v,w)	jit_new_node_www(jit_code_stxai_i,u,v,w)
+    jit_code_stxbr_i,		jit_code_stxbi_i,
+    jit_code_stxar_i,		jit_code_stxai_i,
+#if __WORDSIZE == 32
+#  define jit_stxbr(u,v,w)	jit_stxbr_i(u,v,w)
+#  define jit_stxbi(u,v,w)	jit_stxbi_i(u,v,w)
+#  define jit_stxar(u,v,w)	jit_stxar_i(u,v,w)
+#  define jit_stxai(u,v,w)	jit_stxai_i(u,v,w)
+#else
+#  define jit_stxbr(u,v,w)	jit_stxbr_l(u,v,w)
+#  define jit_stxbi(u,v,w)	jit_stxbi_l(u,v,w)
+#  define jit_stxar(u,v,w)	jit_stxar_l(u,v,w)
+#  define jit_stxai(u,v,w)	jit_stxai_l(u,v,w)
+#  define jit_stxbr_l(u,v,w)	jit_new_node_www(jit_code_stxbr_l,u,v,w)
+#  define jit_stxbi_l(u,v,w)	jit_new_node_www(jit_code_stxbi_l,u,v,w)
+#  define jit_stxar_l(u,v,w)	jit_new_node_www(jit_code_stxar_l,u,v,w)
+#  define jit_stxai_l(u,v,w)	jit_new_node_www(jit_code_stxai_l,u,v,w)
+#endif
+    jit_code_stxbr_l,		jit_code_stxbi_l,
+    jit_code_stxar_l,		jit_code_stxai_l,
+#  define jit_stxbr_f(u,v,w)	jit_new_node_www(jit_code_stxbr_f,u,v,w)
+#  define jit_stxbi_f(u,v,w)	jit_new_node_www(jit_code_stxbi_f,u,v,w)
+#  define jit_stxar_f(u,v,w)	jit_new_node_www(jit_code_stxar_f,u,v,w)
+#  define jit_stxai_f(u,v,w)	jit_new_node_www(jit_code_stxai_f,u,v,w)
+    jit_code_stxbr_f,		jit_code_stxbi_f,
+    jit_code_stxar_f,		jit_code_stxai_f,
+#  define jit_stxbr_d(u,v,w)	jit_new_node_www(jit_code_stxbr_d,u,v,w)
+#  define jit_stxbi_d(u,v,w)	jit_new_node_www(jit_code_stxbi_d,u,v,w)
+#  define jit_stxar_d(u,v,w)	jit_new_node_www(jit_code_stxar_d,u,v,w)
+#  define jit_stxai_d(u,v,w)	jit_new_node_www(jit_code_stxai_d,u,v,w)
+    jit_code_stxbr_d,		jit_code_stxbi_d,
+    jit_code_stxar_d,		jit_code_stxai_d,
+
     jit_code_last_code
 } jit_code_t;
 
@@ -1220,6 +1334,7 @@ typedef void  (*jit_free_func_ptr)	(void*);
 /*
  * Prototypes
  */
+extern void init_jit_with_debug(const char*,FILE*);
 extern void init_jit(const char*);
 extern void finish_jit(void);
 


### PR DESCRIPTION
This had not been done the last time the Lightning subrepo was pulled.

Fixes #825.