### PR TITLE
Update Lightrec 20240513

### DIFF
--- a/deps/lightrec/.gitrepo
+++ b/deps/lightrec/.gitrepo
@@ -6,7 +6,7 @@
 [subrepo]
 	remote = https://github.com/pcercuei/lightrec.git
 	branch = master
-	commit = d88760e40c1d2a5698c7b6f6a53cce31fda799f0
-	parent = 963f41620dce6ddb2527b7e3dced09564031f783
+	commit = c54df45ef1940df2a7afd7c01db734afbfe35b80
+	parent = 672e715c3f3d799e75f3f4a2f9f0db975cdc5e4b
 	method = merge
 	cmdver = 0.4.6

--- a/deps/lightrec/CMakeLists.txt
+++ b/deps/lightrec/CMakeLists.txt
@@ -1,31 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(lightrec LANGUAGES C VERSION 0.8)
-
-set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
-if (NOT BUILD_SHARED_LIBS)
-	add_definitions(-DLIGHTREC_STATIC)
-endif (NOT BUILD_SHARED_LIBS)
-
-if (NOT LOG_LEVEL)
-	set(LOG_LEVEL Info CACHE STRING "Log level" FORCE)
-	set_property(CACHE LOG_LEVEL PROPERTY STRINGS NoLog Error Warning Info Debug)
-endif()
-
-if (NOT CMAKE_BUILD_TYPE)
-	set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
-		"Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel."
-		FORCE)
-	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS None Debug Release RelWithDebInfo MinSizeRel)
-endif()
-
-string(TOUPPER ${LOG_LEVEL} LIGHTREC_LOG_LEVEL)
-add_definitions(-DLOG_LEVEL=${LIGHTREC_LOG_LEVEL}_L)
-
-if (CMAKE_COMPILER_IS_GNUCC)
-	add_compile_options(-fvisibility=hidden)
-endif()
-
-set(HAS_DEFAULT_ELM ${CMAKE_COMPILER_IS_GNUCC})
+project(lightrec LANGUAGES C VERSION 0.9)
 
 list(APPEND LIGHTREC_SOURCES
 	blockcache.c
@@ -52,11 +26,47 @@ list(APPEND LIGHTREC_HEADERS
 	regcache.h
 )
 
+add_library(lightrec ${LIGHTREC_SOURCES} ${LIGHTREC_HEADERS})
+set_target_properties(lightrec PROPERTIES
+	VERSION ${PROJECT_VERSION}
+	SOVERSION ${PROJECT_VERSION_MAJOR}
+	PUBLIC_HEADER lightrec.h
+	C_STANDARD 11
+	C_STANDARD_REQUIRED ON
+	C_EXTENSIONS OFF
+)
+
+set(BUILD_SHARED_LIBS ON CACHE BOOL "Build shared libraries")
+if (NOT BUILD_SHARED_LIBS)
+	target_compile_definitions(lightrec PRIVATE LIGHTREC_STATIC)
+endif (NOT BUILD_SHARED_LIBS)
+
+if (NOT LOG_LEVEL)
+	set(LOG_LEVEL Info CACHE STRING "Log level" FORCE)
+	set_property(CACHE LOG_LEVEL PROPERTY STRINGS NoLog Error Warning Info Debug)
+endif()
+
+if (NOT CMAKE_BUILD_TYPE)
+	set(CMAKE_BUILD_TYPE RelWithDebInfo CACHE STRING
+		"Choose the type of build, options are: None(CMAKE_CXX_FLAGS or CMAKE_C_FLAGS used) Debug Release RelWithDebInfo MinSizeRel."
+		FORCE)
+	set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS None Debug Release RelWithDebInfo MinSizeRel)
+endif()
+
+string(TOUPPER ${LOG_LEVEL} LIGHTREC_LOG_LEVEL)
+target_compile_definitions(lightrec PRIVATE LOG_LEVEL=${LIGHTREC_LOG_LEVEL}_L)
+
+if (CMAKE_COMPILER_IS_GNUCC)
+	target_compile_options(lightrec PRIVATE -fvisibility=hidden)
+endif()
+
+set(HAS_DEFAULT_ELM ${CMAKE_COMPILER_IS_GNUCC})
+
 option(ENABLE_FIRST_PASS "Run the interpreter as first-pass optimization" ON)
 
 option(ENABLE_THREADED_COMPILER "Enable threaded compiler" ON)
 if (ENABLE_THREADED_COMPILER)
-	list(APPEND LIGHTREC_SOURCES recompiler.c reaper.c)
+	target_sources(lightrec PRIVATE recompiler.c reaper.c)
 
 	if (NOT ENABLE_FIRST_PASS)
 		message(SEND_ERROR "Threaded compiler requires first-pass optimization")
@@ -75,54 +85,46 @@ option(OPT_FLAG_MULT_DIV "(optimization) Flag MULT/DIV that only use one of HI/L
 option(OPT_EARLY_UNLOAD "(optimization) Unload registers early" ON)
 option(OPT_PRELOAD_PC "(optimization) Preload PC value into register" ON)
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
-add_library(${PROJECT_NAME} ${LIGHTREC_SOURCES} ${LIGHTREC_HEADERS})
-set_target_properties(${PROJECT_NAME} PROPERTIES
-	VERSION ${PROJECT_VERSION}
-	SOVERSION ${PROJECT_VERSION_MAJOR}
-	PUBLIC_HEADER lightrec.h
-	C_STANDARD 11
-	C_STANDARD_REQUIRED ON
-	C_EXTENSIONS OFF
-)
+target_include_directories(lightrec PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 if (CMAKE_C_COMPILER_ID MATCHES "GNU|Clang")
-	target_compile_options(${PROJECT_NAME} PRIVATE -Wall)
+	target_compile_options(lightrec PRIVATE -Wall)
 endif()
 if (CMAKE_C_COMPILER_ID STREQUAL "Clang")
-	target_compile_options(${PROJECT_NAME} PRIVATE -Wno-initializer-overrides)
+	target_compile_options(lightrec PRIVATE -Wno-initializer-overrides)
 endif()
 
 if (ENABLE_THREADED_COMPILER)
-	find_library(PTHREAD_LIBRARIES pthread REQUIRED)
-	find_path(PTHREAD_INCLUDE_DIR pthread.h REQUIRED)
+	include(FindThreads)
 
-	include_directories(${PTHREAD_INCLUDE_DIR})
-	target_link_libraries(${PROJECT_NAME} PRIVATE ${PTHREAD_LIBRARIES})
+	if (NOT CMAKE_USE_PTHREADS_INIT)
+		message(SEND_ERROR "Could not find compatible threads library")
+	endif()
+
+	target_link_libraries(lightrec PUBLIC Threads::Threads)
 endif (ENABLE_THREADED_COMPILER)
 
 option(ENABLE_CODE_BUFFER "Enable external code buffer" ON)
 if (ENABLE_CODE_BUFFER)
-	target_sources(${PROJECT_NAME} PRIVATE tlsf/tlsf.c)
-	target_include_directories(${PROJECT_NAME} PRIVATE tlsf)
+	target_sources(lightrec PRIVATE tlsf/tlsf.c)
+	target_include_directories(lightrec PRIVATE tlsf)
 endif (ENABLE_CODE_BUFFER)
 
 find_library(LIBLIGHTNING lightning REQUIRED)
 find_path(LIBLIGHTNING_INCLUDE_DIR lightning.h REQUIRED)
 
-include_directories(${LIBLIGHTNING_INCLUDE_DIR})
-target_link_libraries(${PROJECT_NAME} PRIVATE ${LIBLIGHTNING})
+target_include_directories(lightrec PUBLIC ${LIBLIGHTNING_INCLUDE_DIR})
+target_link_libraries(lightrec PUBLIC ${LIBLIGHTNING})
 
 if (LOG_LEVEL STREQUAL Debug)
 	set(ENABLE_DISASSEMBLER ON)
-	target_sources(${PROJECT_NAME} PRIVATE disassembler.c)
+	target_sources(lightrec PRIVATE disassembler.c)
 endif()
 
 configure_file(lightrec-config.h.cmakein lightrec-config.h @ONLY)
 
 include(GNUInstallDirs)
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS lightrec
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/deps/lightrec/constprop.c
+++ b/deps/lightrec/constprop.c
@@ -335,8 +335,9 @@ void lightrec_consts_propagate(const struct block *block,
 
 		case OP_SPECIAL_SRA:
 			v[c.r.rd].value = (s32)v[c.r.rt].value >> c.r.imm;
+			v[c.r.rd].sign = (s32)(v[c.r.rt].sign
+					       | (~v[c.r.rt].known & 0x80000000)) >> c.r.imm;
 			v[c.r.rd].known = (s32)v[c.r.rt].known >> c.r.imm;
-			v[c.r.rd].sign = (s32)v[c.r.rt].sign >> c.r.imm;
 			break;
 
 		case OP_SPECIAL_SLLV:
@@ -370,8 +371,9 @@ void lightrec_consts_propagate(const struct block *block,
 			if ((v[c.r.rs].known & 0x1f) == 0x1f) {
 				imm = v[c.r.rs].value & 0x1f;
 				v[c.r.rd].value = (s32)v[c.r.rt].value >> imm;
+				v[c.r.rd].sign = (s32)(v[c.r.rt].sign
+						       | (~v[c.r.rt].known & 0x80000000)) >> imm;
 				v[c.r.rd].known = (s32)v[c.r.rt].known >> imm;
-				v[c.r.rd].sign = (s32)v[c.r.rt].sign >> imm;
 			} else {
 				v[c.r.rd].known = 0;
 				v[c.r.rd].sign = 0;

--- a/deps/lightrec/emitter.c
+++ b/deps/lightrec/emitter.c
@@ -1258,12 +1258,36 @@ static u32 rec_io_mask(const struct lightrec_state *state)
 	return 0x1f800000 | GENMASK(31 - clz32(length - 1), 0);
 }
 
+static void rec_add_offset(struct lightrec_cstate *cstate,
+			   jit_state_t *_jit, u8 reg_out, u8 reg_in)
+{
+	struct regcache *reg_cache = cstate->reg_cache;
+	u8 reg_imm;
+
+	reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit,
+						     cstate->state->offset);
+	jit_addr(reg_out, reg_in, reg_imm);
+
+	lightrec_free_reg(reg_cache, reg_imm);
+}
+
+static void rec_and_mask(struct lightrec_cstate *cstate,
+			 jit_state_t *_jit, u8 reg_out, u8 reg_in, u32 mask)
+{
+	struct regcache *reg_cache = cstate->reg_cache;
+	u8 reg_imm;
+
+	reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit, mask);
+	jit_andr(reg_out, reg_in, reg_imm);
+
+	lightrec_free_reg(reg_cache, reg_imm);
+}
+
 static void rec_store_memory(struct lightrec_cstate *cstate,
 			     const struct block *block,
 			     u16 offset, jit_code_t code,
 			     jit_code_t swap_code,
-			     uintptr_t addr_offset, u32 addr_mask,
-			     bool invalidate)
+			     u32 addr_mask, bool invalidate)
 {
 	const struct lightrec_state *state = cstate->state;
 	struct regcache *reg_cache = cstate->reg_cache;
@@ -1282,7 +1306,6 @@ static void rec_store_memory(struct lightrec_cstate *cstate,
 	bool need_tmp = !no_mask || add_imm || invalidate;
 	bool swc2 = c.i.op == OP_SWC2;
 	u8 in_reg = swc2 ? REG_TEMP : c.i.rt;
-	s8 reg_imm;
 
 	rs = lightrec_alloc_reg_in(reg_cache, _jit, c.i.rs, 0);
 	if (need_tmp)
@@ -1300,23 +1323,14 @@ static void rec_store_memory(struct lightrec_cstate *cstate,
 	}
 
 	if (!no_mask) {
-		reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit,
-							     addr_mask);
-
-		jit_andr(tmp, addr_reg, reg_imm);
+		rec_and_mask(cstate, _jit, tmp, addr_reg, addr_mask);
 		addr_reg = tmp;
-
-		lightrec_free_reg(reg_cache, reg_imm);
 	}
 
-	if (addr_offset) {
-		reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit,
-							     addr_offset);
+	if (state->offset) {
 		tmp2 = lightrec_alloc_reg_temp(reg_cache, _jit);
-		jit_addr(tmp2, addr_reg, reg_imm);
+		rec_add_offset(cstate, _jit, tmp2, addr_reg);
 		addr_reg2 = tmp2;
-
-		lightrec_free_reg(reg_cache, reg_imm);
 	} else {
 		addr_reg2 = addr_reg;
 	}
@@ -1370,7 +1384,7 @@ static void rec_store_memory(struct lightrec_cstate *cstate,
 		lightrec_free_reg(reg_cache, tmp3);
 	}
 
-	if (addr_offset)
+	if (state->offset)
 		lightrec_free_reg(reg_cache, tmp2);
 	if (need_tmp)
 		lightrec_free_reg(reg_cache, tmp);
@@ -1387,8 +1401,7 @@ static void rec_store_ram(struct lightrec_cstate *cstate,
 	_jit_note(block->_jit, __FILE__, __LINE__);
 
 	return rec_store_memory(cstate, block, offset, code, swap_code,
-				state->offset_ram, rec_ram_mask(state),
-				invalidate);
+				rec_ram_mask(state), invalidate);
 }
 
 static void rec_store_scratch(struct lightrec_cstate *cstate,
@@ -1398,7 +1411,6 @@ static void rec_store_scratch(struct lightrec_cstate *cstate,
 	_jit_note(block->_jit, __FILE__, __LINE__);
 
 	return rec_store_memory(cstate, block, offset, code, swap_code,
-				cstate->state->offset_scratch,
 				0x1fffffff, false);
 }
 
@@ -1409,7 +1421,6 @@ static void rec_store_io(struct lightrec_cstate *cstate,
 	_jit_note(block->_jit, __FILE__, __LINE__);
 
 	return rec_store_memory(cstate, block, offset, code, swap_code,
-				cstate->state->offset_io,
 				rec_io_mask(cstate->state), false);
 }
 
@@ -1419,61 +1430,34 @@ static void rec_store_direct_no_invalidate(struct lightrec_cstate *cstate,
 					   jit_code_t swap_code)
 {
 	const struct lightrec_state *state = cstate->state;
+	u32 ram_size = state->mirrors_mapped ? RAM_SIZE * 4 : RAM_SIZE;
 	struct regcache *reg_cache = cstate->reg_cache;
 	union code c = block->opcode_list[offset].c;
 	jit_state_t *_jit = block->_jit;
-	jit_node_t *to_not_ram, *to_end;
 	bool swc2 = c.i.op == OP_SWC2;
-	u8 tmp, tmp2 = 0, rs, rt, in_reg = swc2 ? REG_TEMP : c.i.rt;
-	u32 addr_mask;
-	s32 reg_imm;
+	u8 addr_reg, tmp, tmp2, rs, rt, in_reg = swc2 ? REG_TEMP : c.i.rt;
 	s16 imm;
 
 	jit_note(__FILE__, __LINE__);
 	rs = lightrec_alloc_reg_in(reg_cache, _jit, c.i.rs, 0);
 	tmp = lightrec_alloc_reg_temp(reg_cache, _jit);
 
-	if (state->mirrors_mapped)
-		addr_mask = 0x1f800000 | (4 * RAM_SIZE - 1);
-	else
-		addr_mask = 0x1f800000 | (RAM_SIZE - 1);
-
-	reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit, addr_mask);
-
 	/* Convert to KUNSEG and avoid RAM mirrors */
 	if ((c.i.op == OP_META_SWU || !state->mirrors_mapped) && c.i.imm) {
 		imm = 0;
 		jit_addi(tmp, rs, (s16)c.i.imm);
-		jit_andr(tmp, tmp, reg_imm);
+		addr_reg = tmp;
 	} else {
 		imm = (s16)c.i.imm;
-		jit_andr(tmp, rs, reg_imm);
+		addr_reg = rs;
 	}
+
+	rec_and_mask(cstate, _jit, tmp, addr_reg, 0x1f800000 | (ram_size - 1));
 
 	lightrec_free_reg(reg_cache, rs);
-	lightrec_free_reg(reg_cache, reg_imm);
 
-	if (state->offset_ram != state->offset_scratch) {
-		tmp2 = lightrec_alloc_reg_temp(reg_cache, _jit);
-
-		to_not_ram = jit_bmsi(tmp, BIT(28));
-
-		jit_movi(tmp2, state->offset_ram);
-
-		to_end = jit_b();
-		jit_patch(to_not_ram);
-
-		jit_movi(tmp2, state->offset_scratch);
-		jit_patch(to_end);
-	} else if (state->offset_ram) {
-		tmp2 = lightrec_alloc_reg_temp_with_value(reg_cache, _jit,
-							  state->offset_ram);
-	}
-
-	if (state->offset_ram || state->offset_scratch) {
-		jit_addr(tmp, tmp, tmp2);
-		lightrec_free_reg(reg_cache, tmp2);
-	}
+	if (state->offset)
+		rec_add_offset(cstate, _jit, tmp, tmp);
 
 	rt = lightrec_alloc_reg_in(reg_cache, _jit, in_reg, 0);
 
@@ -1506,13 +1490,10 @@ static void rec_store_direct(struct lightrec_cstate *cstate, const struct block 
 	struct regcache *reg_cache = cstate->reg_cache;
 	union code c = block->opcode_list[offset].c;
 	jit_state_t *_jit = block->_jit;
-	jit_node_t *to_not_ram, *to_end;
 	bool swc2 = c.i.op == OP_SWC2;
-	u8 tmp, tmp2, tmp3, masked_reg, rs, rt;
+	u8 addr_reg, tmp, tmp2, tmp3, rs, rt;
 	u8 in_reg = swc2 ? REG_TEMP : c.i.rt;
-	u32 addr_mask = 0x1f800000 | (ram_size - 1);
-	bool different_offsets = state->offset_ram != state->offset_scratch;
-	s32 reg_imm;
+	u32 mask;
 
 	jit_note(__FILE__, __LINE__);
 
@@ -1520,34 +1501,25 @@ static void rec_store_direct(struct lightrec_cstate *cstate, const struct block 
 	tmp2 = lightrec_alloc_reg_temp(reg_cache, _jit);
 	tmp3 = lightrec_alloc_reg_in(reg_cache, _jit, 0, 0);
 
-	reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit, addr_mask);
-
 	/* Convert to KUNSEG and avoid RAM mirrors */
 	if (c.i.imm) {
 		jit_addi(tmp2, rs, (s16)c.i.imm);
-		jit_andr(tmp2, tmp2, reg_imm);
+		addr_reg = tmp2;
 	} else {
-		jit_andr(tmp2, rs, reg_imm);
+		addr_reg = rs;
 	}
+
+	rec_and_mask(cstate, _jit, tmp2, addr_reg, 0x1f800000 | (ram_size - 1));
 
 	lightrec_free_reg(reg_cache, rs);
-	lightrec_free_reg(reg_cache, reg_imm);
 	tmp = lightrec_alloc_reg_temp(reg_cache, _jit);
 
-	if (different_offsets) {
-		to_not_ram = jit_bgti(tmp2, ram_size);
-		masked_reg = tmp2;
-	} else {
-		jit_lti_u(tmp, tmp2, ram_size);
-		jit_movnr(tmp, tmp2, tmp);
-		masked_reg = tmp;
-	}
+	jit_lti_u(tmp, tmp2, ram_size);
+	jit_movnr(tmp, tmp2, tmp);
 
 	/* Compute the offset to the code LUT */
-	if (c.i.op == OP_SW)
-		jit_andi(tmp, masked_reg, RAM_SIZE - 1);
-	else
-		jit_andi(tmp, masked_reg, (RAM_SIZE - 1) & ~3);
+	mask = c.i.op == OP_SW ? RAM_SIZE - 1 : (RAM_SIZE - 1) & ~3;
+	rec_and_mask(cstate, _jit, tmp, tmp, mask);
 
 	if (!lut_is_32bit(state))
 		jit_lshi(tmp, tmp, 1);
@@ -1571,21 +1543,8 @@ static void rec_store_direct(struct lightrec_cstate *cstate, const struct block 
 		}
 	}
 
-	if (different_offsets) {
-		jit_movi(tmp, state->offset_ram);
-
-		to_end = jit_b();
-		jit_patch(to_not_ram);
-	}
-
-	if (state->offset_ram || state->offset_scratch)
-		jit_movi(tmp, state->offset_scratch);
-
-	if (different_offsets)
-		jit_patch(to_end);
-
-	if (state->offset_ram || state->offset_scratch)
-		jit_addr(tmp2, tmp2, tmp);
+	if (state->offset)
+		rec_add_offset(cstate, _jit, tmp2, tmp2);
 
 	lightrec_free_reg(reg_cache, tmp);
 	lightrec_free_reg(reg_cache, tmp3);
@@ -1707,9 +1666,10 @@ static void rec_SWR(struct lightrec_cstate *state,
 
 static void rec_load_memory(struct lightrec_cstate *cstate,
 			    const struct block *block, u16 offset,
-			    jit_code_t code, jit_code_t swap_code, bool is_unsigned,
-			    uintptr_t addr_offset, u32 addr_mask)
+			    jit_code_t code, jit_code_t swap_code,
+			    bool is_unsigned, u32 addr_mask)
 {
+	struct lightrec_state *state = cstate->state;
 	struct regcache *reg_cache = cstate->reg_cache;
 	struct opcode *op = &block->opcode_list[offset];
 	bool load_delay = op_flag_load_delay(op->flags) && !cstate->no_load_delay;
@@ -1717,7 +1677,6 @@ static void rec_load_memory(struct lightrec_cstate *cstate,
 	u8 rs, rt, out_reg, addr_reg, flags = REG_EXT;
 	bool no_mask = op_flag_no_mask(op->flags);
 	union code c = op->c;
-	s8 reg_imm;
 	s16 imm;
 
 	if (load_delay || c.i.op == OP_LWC2)
@@ -1734,7 +1693,7 @@ static void rec_load_memory(struct lightrec_cstate *cstate,
 	rt = lightrec_alloc_reg_out(reg_cache, _jit, out_reg, flags);
 
 	if ((op->i.op == OP_META_LWU && c.i.imm)
-	    || (!cstate->state->mirrors_mapped && c.i.imm && !no_mask)) {
+	    || (!state->mirrors_mapped && c.i.imm && !no_mask)) {
 		jit_addi(rt, rs, (s16)c.i.imm);
 		addr_reg = rt;
 		imm = 0;
@@ -1747,23 +1706,13 @@ static void rec_load_memory(struct lightrec_cstate *cstate,
 		imm = LIGHTNING_UNALIGNED_32BIT;
 
 	if (!no_mask) {
-		reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit,
-							     addr_mask);
-
-		jit_andr(rt, addr_reg, reg_imm);
+		rec_and_mask(cstate, _jit, rt, addr_reg, addr_mask);
 		addr_reg = rt;
-
-		lightrec_free_reg(reg_cache, reg_imm);
 	}
 
-	if (addr_offset) {
-		reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit,
-							     addr_offset);
-
-		jit_addr(rt, addr_reg, reg_imm);
+	if (state->offset) {
+		rec_add_offset(cstate, _jit, rt, addr_reg);
 		addr_reg = rt;
-
-		lightrec_free_reg(reg_cache, reg_imm);
 	}
 
 	jit_new_node_www(code, rt, addr_reg, imm);
@@ -1788,7 +1737,7 @@ static void rec_load_ram(struct lightrec_cstate *cstate,
 	_jit_note(block->_jit, __FILE__, __LINE__);
 
 	rec_load_memory(cstate, block, offset, code, swap_code, is_unsigned,
-			cstate->state->offset_ram, rec_ram_mask(cstate->state));
+			rec_ram_mask(cstate->state));
 }
 
 static void rec_load_bios(struct lightrec_cstate *cstate,
@@ -1798,7 +1747,7 @@ static void rec_load_bios(struct lightrec_cstate *cstate,
 	_jit_note(block->_jit, __FILE__, __LINE__);
 
 	rec_load_memory(cstate, block, offset, code, swap_code, is_unsigned,
-			cstate->state->offset_bios, 0x1fffffff);
+			0x1fffffff);
 }
 
 static void rec_load_scratch(struct lightrec_cstate *cstate,
@@ -1808,7 +1757,7 @@ static void rec_load_scratch(struct lightrec_cstate *cstate,
 	_jit_note(block->_jit, __FILE__, __LINE__);
 
 	rec_load_memory(cstate, block, offset, code, swap_code, is_unsigned,
-			cstate->state->offset_scratch, 0x1fffffff);
+			0x1fffffff);
 }
 
 static void rec_load_io(struct lightrec_cstate *cstate,
@@ -1818,7 +1767,7 @@ static void rec_load_io(struct lightrec_cstate *cstate,
 	_jit_note(block->_jit, __FILE__, __LINE__);
 
 	rec_load_memory(cstate, block, offset, code, swap_code, is_unsigned,
-			cstate->state->offset_io, rec_io_mask(cstate->state));
+			rec_io_mask(cstate->state));
 }
 
 static void rec_load_direct(struct lightrec_cstate *cstate,
@@ -1831,13 +1780,10 @@ static void rec_load_direct(struct lightrec_cstate *cstate,
 	struct opcode *op = &block->opcode_list[offset];
 	bool load_delay = op_flag_load_delay(op->flags) && !cstate->no_load_delay;
 	jit_state_t *_jit = block->_jit;
-	jit_node_t *to_not_ram, *to_not_bios, *to_end, *to_end2;
 	u8 tmp, rs, rt, out_reg, addr_reg, flags = REG_EXT;
-	bool different_offsets = state->offset_bios != state->offset_scratch;
 	union code c = op->c;
 	s32 addr_mask;
 	u32 reg_imm;
-	s8 offt_reg;
 	s16 imm;
 
 	if (load_delay || c.i.op == OP_LWC2)
@@ -1854,10 +1800,7 @@ static void rec_load_direct(struct lightrec_cstate *cstate,
 	rs = lightrec_alloc_reg_in(reg_cache, _jit, c.i.rs, 0);
 	rt = lightrec_alloc_reg_out(reg_cache, _jit, out_reg, flags);
 
-	if ((state->offset_ram == state->offset_bios &&
-	    state->offset_ram == state->offset_scratch &&
-	    state->mirrors_mapped && c.i.op != OP_META_LWU)
-	    || !c.i.imm) {
+	if ((state->mirrors_mapped && c.i.op != OP_META_LWU) || !c.i.imm) {
 		addr_reg = rs;
 		imm = (s16)c.i.imm;
 	} else {
@@ -1872,80 +1815,30 @@ static void rec_load_direct(struct lightrec_cstate *cstate,
 	if (op->i.op == OP_META_LWU)
 		imm = LIGHTNING_UNALIGNED_32BIT;
 
-	tmp = lightrec_alloc_reg_temp(reg_cache, _jit);
+	if (!state->mirrors_mapped)
+		addr_mask = 0x1f800000 | (RAM_SIZE - 1);
+	else
+		addr_mask = 0x1fffffff;
 
-	if (state->offset_ram == state->offset_bios &&
-	    state->offset_ram == state->offset_scratch) {
-		if (!state->mirrors_mapped)
-			addr_mask = 0x1f800000 | (RAM_SIZE - 1);
-		else
-			addr_mask = 0x1fffffff;
+	reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit,
+						     addr_mask);
+	if (!state->mirrors_mapped) {
+		tmp = lightrec_alloc_reg_temp(reg_cache, _jit);
 
-		reg_imm = lightrec_alloc_reg_temp_with_value(reg_cache, _jit,
-							     addr_mask);
-		if (!state->mirrors_mapped) {
-			jit_andi(tmp, addr_reg, BIT(28));
-			jit_rshi_u(tmp, tmp, 28 - 22);
-			jit_orr(tmp, tmp, reg_imm);
-			jit_andr(rt, addr_reg, tmp);
-		} else {
-			jit_andr(rt, addr_reg, reg_imm);
-		}
+		jit_andi(tmp, addr_reg, BIT(28));
+		jit_rshi_u(tmp, tmp, 28 - 22);
+		jit_orr(tmp, tmp, reg_imm);
+		jit_andr(rt, addr_reg, tmp);
 
-		lightrec_free_reg(reg_cache, reg_imm);
-
-		if (state->offset_ram) {
-			offt_reg = lightrec_get_reg_with_value(reg_cache,
-							       state->offset_ram);
-			if (offt_reg < 0) {
-				jit_movi(tmp, state->offset_ram);
-				lightrec_temp_set_value(reg_cache, tmp,
-							state->offset_ram);
-			} else {
-				lightrec_free_reg(reg_cache, tmp);
-				tmp = offt_reg;
-			}
-		}
+		lightrec_free_reg(reg_cache, tmp);
 	} else {
-		to_not_ram = jit_bmsi(addr_reg, BIT(28));
-
-		/* Convert to KUNSEG and avoid RAM mirrors */
-		jit_andi(rt, addr_reg, RAM_SIZE - 1);
-
-		if (state->offset_ram)
-			jit_movi(tmp, state->offset_ram);
-
-		to_end = jit_b();
-
-		jit_patch(to_not_ram);
-
-		if (different_offsets)
-			to_not_bios = jit_bmci(addr_reg, BIT(22));
-
-		/* Convert to KUNSEG */
-		jit_andi(rt, addr_reg, 0x1fc00000 | (BIOS_SIZE - 1));
-
-		jit_movi(tmp, state->offset_bios);
-
-		if (different_offsets) {
-			to_end2 = jit_b();
-
-			jit_patch(to_not_bios);
-
-			/* Convert to KUNSEG */
-			jit_andi(rt, addr_reg, 0x1f800fff);
-
-			if (state->offset_scratch)
-				jit_movi(tmp, state->offset_scratch);
-
-			jit_patch(to_end2);
-		}
-
-		jit_patch(to_end);
+		jit_andr(rt, addr_reg, reg_imm);
 	}
 
-	if (state->offset_ram || state->offset_bios || state->offset_scratch)
-		jit_addr(rt, rt, tmp);
+	lightrec_free_reg(reg_cache, reg_imm);
+
+	if (state->offset)
+		rec_add_offset(cstate, _jit, rt, rt);
 
 	jit_new_node_www(code, rt, rt, imm);
 
@@ -1960,7 +1853,6 @@ static void rec_load_direct(struct lightrec_cstate *cstate,
 
 	lightrec_free_reg(reg_cache, addr_reg);
 	lightrec_free_reg(reg_cache, rt);
-	lightrec_free_reg(reg_cache, tmp);
 }
 
 static void rec_load(struct lightrec_cstate *state, const struct block *block,

--- a/deps/lightrec/lightrec-private.h
+++ b/deps/lightrec/lightrec-private.h
@@ -194,7 +194,7 @@ struct lightrec_state {
 	unsigned int nb_compile;
 	unsigned int nb_maps;
 	const struct lightrec_mem_map *maps;
-	uintptr_t offset_ram, offset_bios, offset_scratch, offset_io;
+	uintptr_t offset;
 	u32 opt_flags;
 	_Bool with_32bit_lut;
 	_Bool mirrors_mapped;

--- a/deps/lightrec/optimizer.c
+++ b/deps/lightrec/optimizer.c
@@ -642,7 +642,7 @@ lightrec_remove_useless_lui(struct block *block, unsigned int offset,
 		return;
 	}
 
-	if (op->i.imm != 0 || op->i.rt == 0 || offset == block->nb_ops - 1)
+	if (op->i.imm != 0 || op->i.rt == 0 || is_delay_slot(list, offset))
 		return;
 
 	reader = find_next_reader(list, offset + 1, op->i.rt);
@@ -1002,10 +1002,10 @@ static int lightrec_transform_ops(struct lightrec_state *state, struct block *bl
 			break;
 
 		case OP_LUI:
-			if (i == 0 || !has_delay_slot(list[i - 1].c))
+			if (!is_delay_slot(list, i))
 				lightrec_modify_lui(block, i);
 			lightrec_remove_useless_lui(block, i, v);
-			if (i == 0 || !has_delay_slot(list[i - 1].c))
+			if (!is_delay_slot(list, i))
 				lightrec_lui_to_movi(block, i);
 			break;
 
@@ -2099,7 +2099,7 @@ static int lightrec_flag_mults_divs(struct lightrec_state *state, struct block *
 			list->flags &= ~(LIGHTREC_NO_LO | LIGHTREC_NO_HI);
 		}
 
-		if (reg_lo > 0 && reg_lo != REG_LO) {
+		if (0/* Broken */ && reg_lo > 0 && reg_lo != REG_LO) {
 			pr_debug("Found register %s to hold LO (rs = %u, rt = %u)\n",
 				 lightrec_reg_name(reg_lo), list->r.rs, list->r.rt);
 
@@ -2109,7 +2109,7 @@ static int lightrec_flag_mults_divs(struct lightrec_state *state, struct block *
 			list->r.rd = 0;
 		}
 
-		if (reg_hi > 0 && reg_hi != REG_HI) {
+		if (0/* Broken */ && reg_hi > 0 && reg_hi != REG_HI) {
 			pr_debug("Found register %s to hold HI (rs = %u, rt = %u)\n",
 				 lightrec_reg_name(reg_hi), list->r.rs, list->r.rt);
 

--- a/deps/lightrec/recompiler.c
+++ b/deps/lightrec/recompiler.c
@@ -49,7 +49,7 @@ struct recompiler {
 
 static unsigned int get_processors_count(void)
 {
-	unsigned int nb = 1;
+	int nb = 1;
 
 #if defined(PTW32_VERSION)
         nb = pthread_num_processors_np();
@@ -59,7 +59,7 @@ static unsigned int get_processors_count(void)
 
         nb = sysctlbyname("hw.ncpu", &count, &size, NULL, 0) ? 1 : count;
 #elif defined(_SC_NPROCESSORS_ONLN)
-	nb = sysconf(_SC_NPROCESSORS_ONLN);
+	nb = (int)sysconf(_SC_NPROCESSORS_ONLN);
 #endif
 
 	return nb < 1 ? 1 : nb;

--- a/libpcsxcore/psxmem.c
+++ b/libpcsxcore/psxmem.c
@@ -155,7 +155,7 @@ u8 **psxMemRLUT = NULL;
 
 static int psxMemInitMap(void)
 {
-	psxM = psxMap(0x80000000, 0x00210000, 1, MAP_TAG_RAM);
+	psxM = psxMap(0x10000000, 0x00210000, 1, MAP_TAG_RAM);
 	if (psxM == MAP_FAILED)
 		psxM = psxMap(0x77000000, 0x00210000, 0, MAP_TAG_RAM);
 	if (psxM == MAP_FAILED) {
@@ -165,14 +165,14 @@ static int psxMemInitMap(void)
 	}
 	psxP = &psxM[0x200000];
 
-	psxH = psxMap(0x1f800000, 0x10000, 0, MAP_TAG_OTHER);
+	psxH = psxMap(0x2f800000, 0x10000, 0, MAP_TAG_OTHER);
 	if (psxH == MAP_FAILED) {
 		SysMessage(_("Error allocating memory!"));
 		psxMemShutdown();
 		return -1;
 	}
 
-	psxR = psxMap(0x1fc00000, 0x80000, 0, MAP_TAG_OTHER);
+	psxR = psxMap(0x2fc00000, 0x80000, 0, MAP_TAG_OTHER);
 	if (psxR == MAP_FAILED) {
 		SysMessage(_("Error allocating memory!"));
 		psxMemShutdown();


### PR DESCRIPTION
In order to simplify the code (as it was getting out of hand), Lightrec now requires all the mapped PSX memories to have the same offset relative to their physical address in the PSX address space.

So I also updated the map addresses in psxMem.c. However this relies on `psxMap` succeeding to map to the requested addresses, I don't know if there are platforms where those fail?

One optimization has been disactivated temporarily as it is known to trigger a bug on at least one game.

A few other improvements to the register allocation and code generation, and a fix for CPU count detection.