### PR TITLE
Restore Haiku build

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -124,6 +124,8 @@ endif
 LIBPTHREAD := -lpthread
 ifneq ($(findstring Haiku,$(shell uname -s)),)
 LIBDL := -lroot -lnetwork
+# easiest way to prevent libretro-common from breaking on Haiku
+HAVE_PHYSICAL_CDROM := 0
 else
 LIBDL := -ldl
 endif


### PR DESCRIPTION
Build was failing on Haiku due to cdrom.c in libretro-common, force-disabling CD-ROM code is simplest way to restore Haiku build (until Haiku-specific code is added to libretro-common, eventually)