### PR TITLE
Fixes to libretro makefile for emscripten builds

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -620,10 +620,25 @@ else ifeq ($(platform), emscripten)
    TARGET  := $(TARGET_NAME)_libretro_$(platform).bc
    fpic    := -fPIC
    NO_MMAP = 1
+   # we can use -lz for emscripten's built-in zlib port
+   WANT_ZLIB=0
    CFLAGS += -DNO_DYLIB -DNO_SOCKET
    CFLAGS += -msimd128 -ftree-vectorize
-   LIBPTHREAD :=
-   NO_PTHREAD=1
+   # when compiling with pthreads...
+   ifneq ($(pthread), 0)
+      # use -lpthread
+      LIBPTHREAD := -lpthread
+      NO_PTHREAD=0
+      # but we don't want to include libretro-common's rthread object files here
+      USE_RTHREADS=0
+      USE_ASYNC_CDROM=0
+      # so we disable some uses of threads within pcsx_rearmed.
+      # is this a good solution? I don't know!
+      NDRC_THREAD=0
+   else
+      LIBPTHREAD :=
+      NO_PTHREAD=1
+   endif
    DYNAREC =
    STATIC_LINKING = 1
    HAVE_PHYSICAL_CDROM = 0

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -635,9 +635,10 @@ else ifeq ($(platform), emscripten)
       USE_ASYNC_CDROM=0
       # so we disable some uses of threads within pcsx_rearmed.
       # is this a good solution? I don't know!
-      NDRC_THREAD=0
    else
       LIBPTHREAD :=
+      USE_RTHREADS=0
+      USE_ASYNC_CDROM=0
       NO_PTHREAD=1
    endif
    DYNAREC =

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -618,6 +618,7 @@ else ifeq ($(platform), miyoo)
 # Emscripten
 else ifeq ($(platform), emscripten)
    TARGET  := $(TARGET_NAME)_libretro_$(platform).bc
+   pthread ?= 0
    fpic    := -fPIC
    NO_MMAP = 1
    # we can use -lz for emscripten's built-in zlib port


### PR DESCRIPTION
Now that we can support threads in emscripten, this Makefile should be modified.

I ran into duplicate symbol problems when compiling PCSX's thread support, so I had to disable threads within the emulator to avoid duplicates of rthread.o.  I'd appreciate advice in general on working with cores that could have threading support and including libretro-common under static linking scenarios (since retroarch also includes libretro-common).