### PR TITLE
Improve async CDROM support

### DIFF
--- a/frontend/libretro-cdrom.c
+++ b/frontend/libretro-cdrom.c
@@ -71,7 +71,7 @@ int rcdrom_readSector(void *stream, unsigned int lba, void *b)
    return cdrom_send_command_once(stream, DIRECTION_IN, b, 2352, cmd, sizeof(cmd));
 }
 
-void *rcdrom_open(const char *name, u32 *total_lba)
+void *rcdrom_open(const char *name, u32 *total_lba, u32 *have_subchannel)
 {
    void *g_cd_handle = retro_vfs_file_open_impl(name, RETRO_VFS_FILE_ACCESS_READ,
         RETRO_VFS_FILE_ACCESS_HINT_NONE);
@@ -86,6 +86,7 @@ void *rcdrom_open(const char *name, u32 *total_lba)
       const cdrom_track_t *last = &toc->track[toc->num_tracks - 1];
       unsigned int lba = MSF2SECT(last->min, last->sec, last->frame);
       *total_lba = lba + last->track_size;
+      *have_subchannel = 0;
       //cdrom_get_current_config_random_readable(acdrom.h);
       //cdrom_get_current_config_multiread(acdrom.h);
       //cdrom_get_current_config_cdread(acdrom.h);
@@ -136,6 +137,11 @@ int rcdrom_getStatus(void *stream, struct CdrStat *stat)
 int rcdrom_isMediaInserted(void *stream)
 {
    return cdrom_is_media_inserted(stream);
+}
+
+int rcdrom_readSub(void *stream, unsigned int lba, void *b)
+{
+   return -1;
 }
 
 // vim:sw=3:ts=3:expandtab

--- a/frontend/libretro-cdrom.c
+++ b/frontend/libretro-cdrom.c
@@ -4,6 +4,14 @@
 //#include <linux/cdrom.h>
 #endif
 
+#include "../libpcsxcore/psxcommon.h"
+#include "../libpcsxcore/cdrom.h"
+
+//#include "vfs/vfs_implementation.h"
+#include "vfs/vfs_implementation_cdrom.h"
+
+void *g_cd_handle;
+
 static int cdrom_send_command_dummy(const libretro_vfs_implementation_file *stream,
       CDROM_CMD_Direction dir, void *buf, size_t len, unsigned char *cmd, size_t cmd_len,
       unsigned char *sense, size_t sense_len)
@@ -64,6 +72,71 @@ int cdrom_read_sector(libretro_vfs_implementation_file *stream,
    cmd[4] = lba >> 8;
    cmd[5] = lba;
    return cdrom_send_command_once(stream, DIRECTION_IN, b, 2352, cmd, sizeof(cmd));
+}
+
+int rcdrom_open(const char *name, u32 *total_lba)
+{
+   g_cd_handle = retro_vfs_file_open_impl(name, RETRO_VFS_FILE_ACCESS_READ,
+        RETRO_VFS_FILE_ACCESS_HINT_NONE);
+   if (!g_cd_handle) {
+      SysPrintf("retro_vfs_file_open failed for '%s'\n", name);
+      return -1;
+   }
+   else {
+      int ret = cdrom_set_read_speed_x(g_cd_handle, 4);
+      if (ret) SysPrintf("CD speed set failed\n");
+      const cdrom_toc_t *toc = retro_vfs_file_get_cdrom_toc();
+      const cdrom_track_t *last = &toc->track[toc->num_tracks - 1];
+      unsigned int lba = MSF2SECT(last->min, last->sec, last->frame);
+      *total_lba = lba + last->track_size;
+      //cdrom_get_current_config_random_readable(acdrom.h);
+      //cdrom_get_current_config_multiread(acdrom.h);
+      //cdrom_get_current_config_cdread(acdrom.h);
+      //cdrom_get_current_config_profiles(acdrom.h);
+      return 0;
+   }
+}
+
+void rcdrom_close(void)
+{
+   if (g_cd_handle) {
+      retro_vfs_file_close_impl(g_cd_handle);
+      g_cd_handle = NULL;
+   }
+}
+
+int rcdrom_getTN(u8 *tn)
+{
+   const cdrom_toc_t *toc = retro_vfs_file_get_cdrom_toc();
+   if (toc) {
+     tn[0] = 1;
+     tn[1] = toc->num_tracks;
+     return 0;
+   }
+   return -1;
+}
+
+int rcdrom_getTD(u32 total_lba, u8 track, u8 *rt)
+{
+   const cdrom_toc_t *toc = retro_vfs_file_get_cdrom_toc();
+   rt[0] = 0, rt[1] = 2, rt[2] = 0;
+   if (track == 0) {
+      lba2msf(total_lba + 150, &rt[0], &rt[1], &rt[2]);
+   }
+   else if (track <= toc->num_tracks) {
+      int i = track - 1;
+      rt[0] = toc->track[i].min;
+      rt[1] = toc->track[i].sec;
+      rt[2] = toc->track[i].frame;
+   }
+   return 0;
+}
+
+int rcdrom_getStatus(struct CdrStat *stat)
+{
+   const cdrom_toc_t *toc = retro_vfs_file_get_cdrom_toc();
+   stat->Type = toc->track[0].audio ? 2 : 1;
+   return 0;
 }
 
 // vim:sw=3:ts=3:expandtab

--- a/libpcsxcore/cdrom-async.c
+++ b/libpcsxcore/cdrom-async.c
@@ -26,76 +26,7 @@
 
 #ifdef HAVE_CDROM
 
-#include "vfs/vfs_implementation.h"
-#include "vfs/vfs_implementation_cdrom.h"
-#include "../frontend/libretro-cdrom.h"
-
-static libretro_vfs_implementation_file *g_cd_handle;
-
-static int rcdrom_open(const char *name, u32 *total_lba)
-{
-   g_cd_handle = retro_vfs_file_open_impl(name, RETRO_VFS_FILE_ACCESS_READ,
-        RETRO_VFS_FILE_ACCESS_HINT_NONE);
-   if (!g_cd_handle) {
-      SysPrintf("retro_vfs_file_open failed for '%s'\n", name);
-      return -1;
-   }
-   else {
-      int ret = cdrom_set_read_speed_x(g_cd_handle, 4);
-      if (ret) SysPrintf("CD speed set failed\n");
-      const cdrom_toc_t *toc = retro_vfs_file_get_cdrom_toc();
-      const cdrom_track_t *last = &toc->track[toc->num_tracks - 1];
-      unsigned int lba = MSF2SECT(last->min, last->sec, last->frame);
-      *total_lba = lba + last->track_size;
-      //cdrom_get_current_config_random_readable(acdrom.h);
-      //cdrom_get_current_config_multiread(acdrom.h);
-      //cdrom_get_current_config_cdread(acdrom.h);
-      //cdrom_get_current_config_profiles(acdrom.h);
-      return 0;
-   }
-}
-
-static void rcdrom_close(void)
-{
-   if (g_cd_handle) {
-      retro_vfs_file_close_impl(g_cd_handle);
-      g_cd_handle = NULL;
-   }
-}
-
-static int rcdrom_getTN(u8 *tn)
-{
-   const cdrom_toc_t *toc = retro_vfs_file_get_cdrom_toc();
-   if (toc) {
-     tn[0] = 1;
-     tn[1] = toc->num_tracks;
-     return 0;
-   }
-   return -1;
-}
-
-static int rcdrom_getTD(u32 total_lba, u8 track, u8 *rt)
-{
-   const cdrom_toc_t *toc = retro_vfs_file_get_cdrom_toc();
-   rt[0] = 0, rt[1] = 2, rt[2] = 0;
-   if (track == 0) {
-      lba2msf(total_lba + 150, &rt[0], &rt[1], &rt[2]);
-   }
-   else if (track <= toc->num_tracks) {
-      int i = track - 1;
-      rt[0] = toc->track[i].min;
-      rt[1] = toc->track[i].sec;
-      rt[2] = toc->track[i].frame;
-   }
-   return 0;
-}
-
-static int rcdrom_getStatus(struct CdrStat *stat)
-{
-   const cdrom_toc_t *toc = retro_vfs_file_get_cdrom_toc();
-   stat->Type = toc->track[0].audio ? 2 : 1;
-   return 0;
-}
+extern void *g_cd_handle;
 
 #elif defined(USE_ASYNC_CDROM)
 

--- a/libpcsxcore/cdrom-async.c
+++ b/libpcsxcore/cdrom-async.c
@@ -277,14 +277,14 @@ int cdra_open(void)
 
    acdrom_dbg("%s %s\n", __func__, name);
    acdrom.have_subchannel = 0;
-   if (!strncmp(name, "cdrom:", 6)) {
+   if (!name[0] || !strncmp(name, "cdrom:", 6)) {
       g_cd_handle = rcdrom_open(name, &acdrom.total_lba, &acdrom.have_subchannel);
       if (!!g_cd_handle)
          ret = 0;
    }
 
    // try ISO even if it's cdrom:// as it might work through libretro vfs
-   if (ret < 0) {
+   if (name[0] && ret < 0) {
       ret = ISOopen(name);
       if (ret == 0) {
          u8 msf[3];

--- a/libpcsxcore/cdrom-async.c
+++ b/libpcsxcore/cdrom-async.c
@@ -10,6 +10,7 @@
  *   GNU General Public License for more details.                          *
  ***************************************************************************/
 
+#include <stdalign.h>
 #include <stdlib.h>
 #include <string.h>
 #include "system.h"
@@ -104,12 +105,15 @@ static struct {
    u32 buf_cnt, thread_exit, do_prefetch, prefetch_failed, have_subchannel;
    u32 total_lba, prefetch_lba;
    int check_eject_delay;
-   u8 buf_local[CD_FRAMESIZE_RAW];  // single sector cache, not touched by the thread
+
+   // single sector cache, not touched by the thread
+   alignas(64) u8 buf_local[CD_FRAMESIZE_RAW_ALIGNED];
 } acdrom;
 
 static void lbacache_do(u32 lba)
 {
-   unsigned char msf[3], buf[CD_FRAMESIZE_RAW], buf_sub[SUB_FRAMESIZE];
+   alignas(64) unsigned char buf[CD_FRAMESIZE_RAW_ALIGNED];
+   unsigned char msf[3], buf_sub[SUB_FRAMESIZE];
    u32 i = lba % acdrom.buf_cnt;
    int ret;
 

--- a/libpcsxcore/cdrom-async.c
+++ b/libpcsxcore/cdrom-async.c
@@ -41,7 +41,53 @@ static int  rcdrom_isMediaInserted(void *stream) { return 0; }
 
 #endif
 
+#ifdef USE_C11_THREADS
+#include <threads.h>
+
+static int c11_threads_cb_wrapper(void *cb)
+{
+   ((void (*)(void *))cb)(NULL);
+
+   return 0;
+}
+
+#define slock_new() ({ \
+        mtx_t *lock = malloc(sizeof(*lock)); \
+        if (lock) mtx_init(lock, mtx_plain); \
+        lock; \
+})
+
+#define scond_new() ({ \
+        cnd_t *cnd = malloc(sizeof(*cnd)); \
+        if (cnd) cnd_init(cnd); \
+        cnd; \
+})
+
+#define pcsxr_sthread_create(cb, unused) ({ \
+        thrd_t *thd = malloc(sizeof(*thd)); \
+        if (thd) \
+                thrd_create(thd, c11_threads_cb_wrapper, cb); \
+        thd; \
+})
+
+#define sthread_join(thrd) ({ \
+        thrd_join(*thrd, NULL); \
+        free(thrd); \
+})
+
+#define slock_free(lock) free(lock)
+#define slock_lock(lock) mtx_lock(lock)
+#define slock_unlock(lock) mtx_unlock(lock)
+#define scond_free(cond) free(cond)
+#define scond_wait(cond, lock) cnd_wait(cond, lock)
+#define scond_signal(cond) cnd_signal(cond)
+#define slock_t mtx_t
+#define scond_t cnd_t
+#define sthread_t thrd_t
+#else
 #include "../frontend/libretro-rthreads.h"
+#endif
+
 #include "retro_timers.h"
 
 struct cached_buf {

--- a/libpcsxcore/cdrom-async.h
+++ b/libpcsxcore/cdrom-async.h
@@ -1,9 +1,21 @@
+#include "psxcommon.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 struct CdrStat;
+
+#ifdef HAVE_CDROM
+int  rcdrom_open(const char *name, u32 *total_lba);
+void rcdrom_close(void);
+int  rcdrom_getTN(u8 *tn);
+int  rcdrom_getTD(u32 total_lba, u8 track, u8 *rt);
+int  rcdrom_getStatus(struct CdrStat *stat);
+
+int cdrom_read_sector(void *stream, unsigned int lba, void *b);
+int cdrom_is_media_inserted(void *stream);
+#endif
 
 int  cdra_init(void);
 void cdra_shutdown(void);

--- a/libpcsxcore/cdrom-async.h
+++ b/libpcsxcore/cdrom-async.h
@@ -7,12 +7,13 @@ extern "C" {
 struct CdrStat;
 
 #ifdef HAVE_CDROM
-void *rcdrom_open(const char *name, u32 *total_lba);
+void *rcdrom_open(const char *name, u32 *total_lba, u32 *have_sub);
 void rcdrom_close(void *stream);
 int  rcdrom_getTN(void *stream, u8 *tn);
 int  rcdrom_getTD(void *stream, u32 total_lba, u8 track, u8 *rt);
 int  rcdrom_getStatus(void *stream, struct CdrStat *stat);
 int  rcdrom_readSector(void *stream, unsigned int lba, void *b);
+int  rcdrom_readSub(void *stream, unsigned int lba, void *b);
 int  rcdrom_isMediaInserted(void *stream);
 #endif
 

--- a/libpcsxcore/cdrom-async.h
+++ b/libpcsxcore/cdrom-async.h
@@ -7,14 +7,13 @@ extern "C" {
 struct CdrStat;
 
 #ifdef HAVE_CDROM
-int  rcdrom_open(const char *name, u32 *total_lba);
-void rcdrom_close(void);
-int  rcdrom_getTN(u8 *tn);
-int  rcdrom_getTD(u32 total_lba, u8 track, u8 *rt);
-int  rcdrom_getStatus(struct CdrStat *stat);
-
-int cdrom_read_sector(void *stream, unsigned int lba, void *b);
-int cdrom_is_media_inserted(void *stream);
+void *rcdrom_open(const char *name, u32 *total_lba);
+void rcdrom_close(void *stream);
+int  rcdrom_getTN(void *stream, u8 *tn);
+int  rcdrom_getTD(void *stream, u32 total_lba, u8 track, u8 *rt);
+int  rcdrom_getStatus(void *stream, struct CdrStat *stat);
+int  rcdrom_readSector(void *stream, unsigned int lba, void *b);
+int  rcdrom_isMediaInserted(void *stream);
 #endif
 
 int  cdra_init(void);

--- a/libpcsxcore/cdrom.c
+++ b/libpcsxcore/cdrom.c
@@ -21,6 +21,7 @@
 * Handles all CD-ROM registers and functions.
 */
 
+#include <stdalign.h>
 #include <assert.h>
 #include "cdrom.h"
 #include "cdrom-async.h"
@@ -124,7 +125,7 @@ static struct {
 	u8 AttenuatorLeftToLeftT, AttenuatorLeftToRightT;
 	u8 AttenuatorRightToRightT, AttenuatorRightToLeftT;
 } cdr;
-static s16 read_buf[CD_FRAMESIZE_RAW/2];
+alignas(64) static s16 read_buf[CD_FRAMESIZE_RAW_ALIGNED / 2];
 
 struct SubQ {
 	char res0[12];

--- a/libpcsxcore/cdrom.h
+++ b/libpcsxcore/cdrom.h
@@ -41,6 +41,10 @@ extern "C" {
 #define CD_FRAMESIZE_RAW		2352
 #define DATA_SIZE				(CD_FRAMESIZE_RAW - 12)
 
+/* CD_FRAMESIZE_RAW aligned to a cache line for DMA buffers
+ * (assuming a cache line of max. 64 bytes) */
+#define CD_FRAMESIZE_RAW_ALIGNED	2368
+
 #define SUB_FRAMESIZE			96
 
 #define MSF2SECT(m, s, f)		(((m) * 60 + (s) - 2) * 75 + (f))


### PR DESCRIPTION
- Decouple libretro from the async-cdrom code. Libretro has no business being in libpcsxcore.
- Add C11 threads wrapper for non-libretro platforms
- Add support for reading subchannel data with hardware CD-ROM readers
- Misc. fixes.

This allows me to use the async. CDROM functionality with ISOs and hardware CD-ROM in my Bloom downstream PSX emulator for Dreamcast.

Note that I suspect the async CDROM code to be slightly buggy, regarding subchannel data. If I enable subchannel reads in my CDROM driver (set `acdrom.have_subchannel`), libcrypt games will boot (FF8 in my case) properly, but some other games (original copy of Need for Speed) won't boot unless disabled.