### PR TITLE
use https:// URL for gnulib in .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,4 @@
 [submodule "deps/lightning/gnulib"]
 	active = false
 	path = deps/lightning/gnulib
-	url = git://git.sv.gnu.org/gnulib.git
+	url = https://git.savannah.gnu.org/git/gnulib.git


### PR DESCRIPTION

HTTPS Everywhere! This is a trivial fix to improve privacy and security.